### PR TITLE
chore: use lucid-fabrics org for github sponsors

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,2 @@
-github: wmehanna
+github: lucid-fabrics
 ko_fi: lucidfabrics

--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ Enables pre-commit, commit-msg, and pre-push hooks for:
 This project is free and open source. Sponsors keep it alive and shape what gets built next.
 
 <p align="center">
-  <a href="https://github.com/sponsors/wmehanna">
+  <a href="https://github.com/sponsors/lucid-fabrics">
     <img src="https://img.shields.io/badge/Sponsor-GitHub-EA4AAA?logo=github&logoColor=white" alt="Sponsor on GitHub">
   </a>
   &nbsp;


### PR DESCRIPTION
## Summary
Switch GitHub Sponsors entry from `wmehanna` to `lucid-fabrics` org now that the org Sponsors profile is set up.

## Changes
- `.github/FUNDING.yml` — `github: lucid-fabrics`
- `README.md` — sponsor badge links to org profile