### PR TITLE
feat: auto-download OpenCore ISOs and macOS recovery images

### DIFF
--- a/src/osx_proxmox_next/downloader.py
+++ b/src/osx_proxmox_next/downloader.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import gzip
+import plistlib
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from json import loads as json_loads
+from pathlib import Path
+from typing import Callable, Optional
+
+from . import __version__
+
+
+@dataclass
+class DownloadProgress:
+    downloaded: int
+    total: int  # 0 if unknown
+    phase: str  # "opencore" | "recovery"
+
+
+ProgressCallback = Optional[Callable[[DownloadProgress], None]]
+
+
+class DownloadError(Exception):
+    pass
+
+
+RECOVERY_CATALOG: dict[str, dict[str, str]] = {
+    "sonoma": {
+        "board_id": "Mac-27AD2F918AE68F61",
+        "catalog_url": (
+            "https://swscan.apple.com/content/catalogs/others/"
+            "index-14-13-12-10.16-10.15-10.14-10.13-10.12-10.11-10.10-10.9"
+            "-mountainlion-lion-snowleopard-leopard.merged-1.sucatalog.gz"
+        ),
+    },
+    "sequoia": {
+        "board_id": "Mac-27AD2F918AE68F61",
+        "catalog_url": (
+            "https://swscan.apple.com/content/catalogs/others/"
+            "index-15-14-13-12-10.16-10.15-10.14-10.13-10.12-10.11-10.10-10.9"
+            "-mountainlion-lion-snowleopard-leopard.merged-1.sucatalog.gz"
+        ),
+    },
+}
+
+_GITHUB_API = "https://api.github.com/repos/lucid-fabrics/osx-proxmox-next/releases"
+_CHUNK_SIZE = 65536
+_MAX_RETRIES = 3
+_BACKOFF_SECONDS = [1, 2, 4]
+
+
+def download_opencore(
+    macos: str,
+    dest_dir: Path,
+    on_progress: ProgressCallback = None,
+) -> Path:
+    version = __version__
+    asset_name = f"opencore-{macos}.iso"
+    dest = dest_dir / asset_name
+
+    if dest.exists():
+        return dest
+
+    release = _fetch_github_release(version)
+    browser_url = _find_release_asset(release, asset_name)
+
+    _download_file(browser_url, dest, on_progress, "opencore")
+    return dest
+
+
+def download_recovery(
+    macos: str,
+    dest_dir: Path,
+    on_progress: ProgressCallback = None,
+) -> Path:
+    if macos == "tahoe":
+        raise DownloadError(
+            "Tahoe requires a full installer image. "
+            "Auto-download is not available for Tahoe recovery."
+        )
+
+    if macos not in RECOVERY_CATALOG:
+        raise DownloadError(f"No recovery catalog entry for '{macos}'.")
+
+    dest = dest_dir / f"{macos}-recovery.img"
+    if dest.exists():
+        return dest
+
+    catalog_info = RECOVERY_CATALOG[macos]
+    base_system_url = _find_base_system_url(
+        catalog_info["catalog_url"],
+        catalog_info["board_id"],
+    )
+
+    _download_file(base_system_url, dest, on_progress, "recovery")
+    return dest
+
+
+def _fetch_github_release(version: str) -> dict:
+    tag_url = f"{_GITHUB_API}/tags/v{version}"
+    try:
+        data = _http_get_json(tag_url)
+        return data
+    except (urllib.error.HTTPError, DownloadError):
+        pass
+
+    latest_url = f"{_GITHUB_API}/latest"
+    try:
+        data = _http_get_json(latest_url)
+        return data
+    except (urllib.error.HTTPError, DownloadError) as exc:
+        raise DownloadError(
+            f"Could not fetch GitHub release (tried v{version} and latest): {exc}"
+        ) from exc
+
+
+def _find_release_asset(release: dict, asset_name: str) -> str:
+    for asset in release.get("assets", []):
+        if asset.get("name") == asset_name:
+            url = asset.get("browser_download_url", "")
+            if url:
+                return url
+    raise DownloadError(
+        f"Asset '{asset_name}' not found in release '{release.get('tag_name', '?')}'."
+    )
+
+
+def _find_base_system_url(catalog_url: str, board_id: str) -> str:
+    try:
+        req = urllib.request.Request(catalog_url, headers={"User-Agent": "osx-proxmox-next"})
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            raw = resp.read()
+    except Exception as exc:
+        raise DownloadError(f"Failed to fetch Apple catalog: {exc}") from exc
+
+    try:
+        xml_data = gzip.decompress(raw)
+    except gzip.BadGzipFile:
+        xml_data = raw
+
+    try:
+        catalog = plistlib.loads(xml_data)
+    except Exception as exc:
+        raise DownloadError(f"Failed to parse Apple catalog plist: {exc}") from exc
+
+    products = catalog.get("Products", {})
+    candidate_url = ""
+
+    for _prod_id, product in products.items():
+        packages = product.get("Packages", [])
+        base_system_pkg = ""
+        for pkg in packages:
+            pkg_url = pkg.get("URL", "")
+            if "BaseSystem.dmg" in pkg_url:
+                base_system_pkg = pkg_url
+                break
+
+        if not base_system_pkg:
+            continue
+
+        raw_boards = str(product.get("ExtendedMetaInfo", {}).get("InstallAssistantPackageIdentifiers", {}))
+        if board_id in raw_boards:
+            candidate_url = base_system_pkg
+        elif not candidate_url:
+            candidate_url = base_system_pkg
+
+    if not candidate_url:
+        raise DownloadError(
+            f"Could not find BaseSystem.dmg in Apple catalog for board ID '{board_id}'."
+        )
+
+    return candidate_url
+
+
+def _download_file(
+    url: str,
+    dest: Path,
+    on_progress: ProgressCallback,
+    phase: str,
+) -> None:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    part_path = dest.parent / (dest.name + ".part")
+
+    last_error: Optional[Exception] = None
+    for attempt in range(_MAX_RETRIES):
+        try:
+            _do_download(url, part_path, on_progress, phase)
+            part_path.rename(dest)
+            return
+        except Exception as exc:
+            last_error = exc
+            if part_path.exists():
+                part_path.unlink()
+            if attempt < _MAX_RETRIES - 1:
+                time.sleep(_BACKOFF_SECONDS[attempt])
+
+    raise DownloadError(f"Download failed after {_MAX_RETRIES} attempts: {last_error}")
+
+
+def _do_download(
+    url: str,
+    dest: Path,
+    on_progress: ProgressCallback,
+    phase: str,
+) -> None:
+    req = urllib.request.Request(url, headers={"User-Agent": "osx-proxmox-next"})
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        total = int(resp.headers.get("Content-Length", 0))
+        downloaded = 0
+        with open(dest, "wb") as f:
+            while True:
+                chunk = resp.read(_CHUNK_SIZE)
+                if not chunk:
+                    break
+                f.write(chunk)
+                downloaded += len(chunk)
+                if on_progress:
+                    on_progress(DownloadProgress(
+                        downloaded=downloaded,
+                        total=total,
+                        phase=phase,
+                    ))
+
+
+def _http_get_json(url: str) -> dict:
+    req = urllib.request.Request(url, headers={
+        "User-Agent": "osx-proxmox-next",
+        "Accept": "application/vnd.github+json",
+    })
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        return json_loads(resp.read())

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -1,0 +1,461 @@
+from __future__ import annotations
+
+import io
+import json
+import urllib.error
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import osx_proxmox_next.downloader as dl_module
+from osx_proxmox_next.downloader import (
+    DownloadError,
+    DownloadProgress,
+    download_opencore,
+    download_recovery,
+    _download_file,
+    _fetch_github_release,
+    _find_release_asset,
+)
+
+
+def _make_response(data: bytes, content_length: int | None = None):
+    """Create a fake HTTP response object."""
+    resp = MagicMock()
+    resp.read = MagicMock(side_effect=[data, b""])
+    resp.headers = {"Content-Length": str(content_length) if content_length else "0"}
+    resp.__enter__ = MagicMock(return_value=resp)
+    resp.__exit__ = MagicMock(return_value=False)
+    return resp
+
+
+def _make_chunked_response(chunks: list[bytes], content_length: int | None = None):
+    """Create a fake HTTP response that returns data in chunks."""
+    resp = MagicMock()
+    resp.read = MagicMock(side_effect=chunks + [b""])
+    resp.headers = {"Content-Length": str(content_length) if content_length else "0"}
+    resp.__enter__ = MagicMock(return_value=resp)
+    resp.__exit__ = MagicMock(return_value=False)
+    return resp
+
+
+class TestDownloadOpencore:
+    def test_success(self, tmp_path, monkeypatch):
+        release_json = {
+            "tag_name": "v0.3.0",
+            "assets": [
+                {
+                    "name": "opencore-sequoia.iso",
+                    "browser_download_url": "https://example.com/opencore-sequoia.iso",
+                }
+            ],
+        }
+        api_resp = _make_response(json.dumps(release_json).encode())
+        file_data = b"fake-iso-content-" * 100
+        file_resp = _make_chunked_response([file_data], len(file_data))
+
+        call_count = [0]
+
+        def fake_urlopen(req, timeout=None):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return api_resp
+            return file_resp
+
+        monkeypatch.setattr(dl_module.urllib.request, "urlopen", fake_urlopen)
+        monkeypatch.setattr(dl_module, "__version__", "0.3.0")
+        monkeypatch.setattr(dl_module.time, "sleep", lambda s: None)
+
+        result = download_opencore("sequoia", tmp_path)
+        assert result == tmp_path / "opencore-sequoia.iso"
+        assert result.exists()
+
+    def test_fallback_latest(self, tmp_path, monkeypatch):
+        release_json = {
+            "tag_name": "v0.2.0",
+            "assets": [
+                {
+                    "name": "opencore-sequoia.iso",
+                    "browser_download_url": "https://example.com/opencore-sequoia.iso",
+                }
+            ],
+        }
+        api_resp = _make_response(json.dumps(release_json).encode())
+        file_data = b"iso-data"
+        file_resp = _make_chunked_response([file_data], len(file_data))
+
+        call_count = [0]
+
+        def fake_urlopen(req, timeout=None):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise urllib.error.HTTPError(req.full_url, 404, "Not Found", {}, io.BytesIO(b""))
+            if call_count[0] == 2:
+                return api_resp
+            return file_resp
+
+        monkeypatch.setattr(dl_module.urllib.request, "urlopen", fake_urlopen)
+        monkeypatch.setattr(dl_module, "__version__", "99.99.99")
+        monkeypatch.setattr(dl_module.time, "sleep", lambda s: None)
+
+        result = download_opencore("sequoia", tmp_path)
+        assert result == tmp_path / "opencore-sequoia.iso"
+
+    def test_no_matching_asset(self, tmp_path, monkeypatch):
+        release_json = {
+            "tag_name": "v0.3.0",
+            "assets": [
+                {"name": "other-file.zip", "browser_download_url": "https://example.com/other.zip"}
+            ],
+        }
+        api_resp = _make_response(json.dumps(release_json).encode())
+
+        monkeypatch.setattr(dl_module.urllib.request, "urlopen", lambda req, timeout=None: api_resp)
+        monkeypatch.setattr(dl_module, "__version__", "0.3.0")
+
+        with pytest.raises(DownloadError, match="not found in release"):
+            download_opencore("sequoia", tmp_path)
+
+    def test_existing_file_skips_download(self, tmp_path, monkeypatch):
+        existing = tmp_path / "opencore-sequoia.iso"
+        existing.write_text("already here")
+
+        result = download_opencore("sequoia", tmp_path)
+        assert result == existing
+
+
+class TestDownloadRecovery:
+    def test_tahoe_rejected(self, tmp_path):
+        with pytest.raises(DownloadError, match="Tahoe requires a full installer"):
+            download_recovery("tahoe", tmp_path)
+
+    def test_unknown_macos_rejected(self, tmp_path):
+        with pytest.raises(DownloadError, match="No recovery catalog entry"):
+            download_recovery("unknown_os", tmp_path)
+
+    def test_existing_file_skips_download(self, tmp_path):
+        existing = tmp_path / "sequoia-recovery.img"
+        existing.write_text("already here")
+
+        result = download_recovery("sequoia", tmp_path)
+        assert result == existing
+
+    def test_success(self, tmp_path, monkeypatch):
+        import gzip
+        import plistlib
+
+        catalog = {
+            "Products": {
+                "prod1": {
+                    "Packages": [
+                        {"URL": "https://apple.com/BaseSystem.dmg", "Size": 500},
+                    ],
+                    "ExtendedMetaInfo": {
+                        "InstallAssistantPackageIdentifiers": {
+                            "SharedSupport": "com.apple.pkg.InstallAssistant.macOS15"
+                        }
+                    },
+                }
+            }
+        }
+        catalog_xml = plistlib.dumps(catalog)
+        catalog_gz = gzip.compress(catalog_xml)
+        catalog_resp = _make_response(catalog_gz)
+
+        file_data = b"basesystem-dmg-content"
+        file_resp = _make_chunked_response([file_data], len(file_data))
+
+        call_count = [0]
+
+        def fake_urlopen(req, timeout=None):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return catalog_resp
+            return file_resp
+
+        monkeypatch.setattr(dl_module.urllib.request, "urlopen", fake_urlopen)
+        monkeypatch.setattr(dl_module.time, "sleep", lambda s: None)
+
+        result = download_recovery("sequoia", tmp_path)
+        assert result == tmp_path / "sequoia-recovery.img"
+        assert result.exists()
+
+
+class TestDownloadFile:
+    def test_partial_cleanup(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(dl_module.time, "sleep", lambda s: None)
+
+        call_count = [0]
+
+        def fake_urlopen(req, timeout=None):
+            call_count[0] += 1
+            raise ConnectionError("network failure")
+
+        monkeypatch.setattr(dl_module.urllib.request, "urlopen", fake_urlopen)
+
+        dest = tmp_path / "test.iso"
+        with pytest.raises(DownloadError, match="Download failed after"):
+            _download_file("https://example.com/file.iso", dest, None, "opencore")
+
+        assert not dest.exists()
+        assert not (tmp_path / "test.iso.part").exists()
+
+    def test_partial_file_cleaned_up(self, tmp_path, monkeypatch):
+        """When .part file is created but download fails mid-stream, it gets cleaned up."""
+        monkeypatch.setattr(dl_module.time, "sleep", lambda s: None)
+
+        original_do_download = dl_module._do_download
+        call_count = [0]
+
+        def failing_do_download(url, dest, on_progress, phase):
+            call_count[0] += 1
+            # Write partial data then fail
+            dest.write_bytes(b"partial data")
+            raise ConnectionError("mid-download failure")
+
+        monkeypatch.setattr(dl_module, "_do_download", failing_do_download)
+
+        dest = tmp_path / "test.iso"
+        with pytest.raises(DownloadError, match="Download failed after"):
+            _download_file("https://example.com/file.iso", dest, None, "opencore")
+
+        assert not dest.exists()
+        assert not (tmp_path / "test.iso.part").exists()
+
+    def test_retry_succeeds(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(dl_module.time, "sleep", lambda s: None)
+
+        file_data = b"success-data"
+        file_resp = _make_chunked_response([file_data], len(file_data))
+
+        call_count = [0]
+
+        def fake_urlopen(req, timeout=None):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise ConnectionError("transient error")
+            return file_resp
+
+        monkeypatch.setattr(dl_module.urllib.request, "urlopen", fake_urlopen)
+
+        dest = tmp_path / "retry-test.iso"
+        _download_file("https://example.com/file.iso", dest, None, "opencore")
+        assert dest.exists()
+        assert dest.read_bytes() == file_data
+
+    def test_progress_callback(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(dl_module.time, "sleep", lambda s: None)
+
+        chunk1 = b"a" * 1000
+        chunk2 = b"b" * 500
+        total = len(chunk1) + len(chunk2)
+        file_resp = _make_chunked_response([chunk1, chunk2], total)
+
+        monkeypatch.setattr(dl_module.urllib.request, "urlopen", lambda req, timeout=None: file_resp)
+
+        progress_calls: list[DownloadProgress] = []
+
+        def on_progress(p: DownloadProgress) -> None:
+            progress_calls.append(p)
+
+        dest = tmp_path / "progress-test.iso"
+        _download_file("https://example.com/file.iso", dest, on_progress, "recovery")
+
+        assert len(progress_calls) == 2
+        assert progress_calls[0].downloaded == 1000
+        assert progress_calls[0].total == total
+        assert progress_calls[0].phase == "recovery"
+        assert progress_calls[1].downloaded == 1500
+        assert progress_calls[1].total == total
+
+
+class TestFetchGithubRelease:
+    def test_tag_success(self, monkeypatch):
+        release = {"tag_name": "v0.3.0", "assets": []}
+        resp = _make_response(json.dumps(release).encode())
+        monkeypatch.setattr(dl_module.urllib.request, "urlopen", lambda req, timeout=None: resp)
+        monkeypatch.setattr(dl_module, "__version__", "0.3.0")
+
+        result = _fetch_github_release("0.3.0")
+        assert result["tag_name"] == "v0.3.0"
+
+    def test_both_fail(self, monkeypatch):
+        def fail(req, timeout=None):
+            raise urllib.error.HTTPError(req.full_url, 404, "Not Found", {}, io.BytesIO(b""))
+
+        monkeypatch.setattr(dl_module.urllib.request, "urlopen", fail)
+
+        with pytest.raises(DownloadError, match="Could not fetch GitHub release"):
+            _fetch_github_release("99.0.0")
+
+
+class TestFindReleaseAsset:
+    def test_found(self):
+        release = {
+            "tag_name": "v0.3.0",
+            "assets": [
+                {"name": "opencore-sequoia.iso", "browser_download_url": "https://dl.example.com/oc.iso"},
+            ],
+        }
+        url = _find_release_asset(release, "opencore-sequoia.iso")
+        assert url == "https://dl.example.com/oc.iso"
+
+    def test_not_found(self):
+        release = {"tag_name": "v0.3.0", "assets": []}
+        with pytest.raises(DownloadError, match="not found in release"):
+            _find_release_asset(release, "opencore-sequoia.iso")
+
+    def test_empty_url(self):
+        release = {
+            "tag_name": "v0.3.0",
+            "assets": [
+                {"name": "opencore-sequoia.iso", "browser_download_url": ""},
+            ],
+        }
+        with pytest.raises(DownloadError, match="not found in release"):
+            _find_release_asset(release, "opencore-sequoia.iso")
+
+
+class TestHttpGetJson:
+    def test_network_error_propagates(self, monkeypatch):
+        from osx_proxmox_next.downloader import _http_get_json
+
+        def fail(req, timeout=None):
+            raise ConnectionError("no network")
+
+        monkeypatch.setattr(dl_module.urllib.request, "urlopen", fail)
+
+        with pytest.raises(ConnectionError, match="no network"):
+            _http_get_json("https://api.github.com/repos/test/releases/latest")
+
+
+class TestFindBaseSystemUrl:
+    def test_catalog_fetch_error(self, monkeypatch):
+        from osx_proxmox_next.downloader import _find_base_system_url
+
+        def fail(req, timeout=None):
+            raise ConnectionError("no network")
+
+        monkeypatch.setattr(dl_module.urllib.request, "urlopen", fail)
+
+        with pytest.raises(DownloadError, match="Failed to fetch Apple catalog"):
+            _find_base_system_url("https://example.com/catalog.gz", "Mac-ABC")
+
+    def test_bad_plist(self, monkeypatch):
+        from osx_proxmox_next.downloader import _find_base_system_url
+
+        resp = _make_response(b"not valid plist data")
+        monkeypatch.setattr(dl_module.urllib.request, "urlopen", lambda req, timeout=None: resp)
+
+        with pytest.raises(DownloadError, match="Failed to parse Apple catalog"):
+            _find_base_system_url("https://example.com/catalog.gz", "Mac-ABC")
+
+    def test_no_basesystem_in_catalog(self, monkeypatch):
+        import gzip
+        import plistlib
+        from osx_proxmox_next.downloader import _find_base_system_url
+
+        catalog = {
+            "Products": {
+                "prod1": {
+                    "Packages": [
+                        {"URL": "https://apple.com/other.pkg"},
+                    ],
+                }
+            }
+        }
+        catalog_xml = plistlib.dumps(catalog)
+        catalog_gz = gzip.compress(catalog_xml)
+        resp = _make_response(catalog_gz)
+        monkeypatch.setattr(dl_module.urllib.request, "urlopen", lambda req, timeout=None: resp)
+
+        with pytest.raises(DownloadError, match="Could not find BaseSystem.dmg"):
+            _find_base_system_url("https://example.com/catalog.gz", "Mac-ZZZZZ")
+
+    def test_board_id_match(self, monkeypatch):
+        import gzip
+        import plistlib
+        from osx_proxmox_next.downloader import _find_base_system_url
+
+        catalog = {
+            "Products": {
+                "prod1": {
+                    "Packages": [
+                        {"URL": "https://apple.com/BaseSystem.dmg"},
+                    ],
+                    "ExtendedMetaInfo": {
+                        "InstallAssistantPackageIdentifiers": {
+                            "SharedSupport": "Mac-27AD2F918AE68F61"
+                        }
+                    },
+                },
+                "prod2": {
+                    "Packages": [
+                        {"URL": "https://apple.com/other-BaseSystem.dmg"},
+                    ],
+                    "ExtendedMetaInfo": {},
+                },
+            }
+        }
+        catalog_xml = plistlib.dumps(catalog)
+        catalog_gz = gzip.compress(catalog_xml)
+        resp = _make_response(catalog_gz)
+        monkeypatch.setattr(dl_module.urllib.request, "urlopen", lambda req, timeout=None: resp)
+
+        result = _find_base_system_url("https://example.com/catalog.gz", "Mac-27AD2F918AE68F61")
+        assert result == "https://apple.com/BaseSystem.dmg"
+
+    def test_uncompressed_catalog(self, monkeypatch):
+        import plistlib
+        from osx_proxmox_next.downloader import _find_base_system_url
+
+        catalog = {
+            "Products": {
+                "prod1": {
+                    "Packages": [
+                        {"URL": "https://apple.com/BaseSystem.dmg"},
+                    ],
+                    "ExtendedMetaInfo": {
+                        "InstallAssistantPackageIdentifiers": {
+                            "SharedSupport": "Mac-TESTBOARD"
+                        }
+                    },
+                }
+            }
+        }
+        catalog_xml = plistlib.dumps(catalog)
+        # Send uncompressed data (not gzipped)
+        resp = _make_response(catalog_xml)
+        monkeypatch.setattr(dl_module.urllib.request, "urlopen", lambda req, timeout=None: resp)
+
+        result = _find_base_system_url("https://example.com/catalog.xml", "Mac-TESTBOARD")
+        assert "BaseSystem.dmg" in result
+
+    def test_fallback_candidate_when_no_board_match(self, monkeypatch):
+        """When board_id doesn't match any product, falls back to first BaseSystem.dmg found."""
+        import gzip
+        import plistlib
+        from osx_proxmox_next.downloader import _find_base_system_url
+
+        catalog = {
+            "Products": {
+                "prod1": {
+                    "Packages": [
+                        {"URL": "https://apple.com/fallback-BaseSystem.dmg"},
+                    ],
+                    "ExtendedMetaInfo": {
+                        "InstallAssistantPackageIdentifiers": {
+                            "SharedSupport": "Mac-DIFFERENT"
+                        }
+                    },
+                }
+            }
+        }
+        catalog_xml = plistlib.dumps(catalog)
+        catalog_gz = gzip.compress(catalog_xml)
+        resp = _make_response(catalog_gz)
+        monkeypatch.setattr(dl_module.urllib.request, "urlopen", lambda req, timeout=None: resp)
+
+        result = _find_base_system_url("https://example.com/catalog.gz", "Mac-NOMATCH")
+        assert result == "https://apple.com/fallback-BaseSystem.dmg"


### PR DESCRIPTION
## Summary
- Adds `downloader` module to fetch OpenCore ISOs from GitHub releases and macOS recovery images from Apple's software update catalog
- Missing assets auto-download during `apply`; new `download` subcommand for explicit use
- TUI gets a "Download Missing" button in Step 3

## Changes
- `src/osx_proxmox_next/downloader.py` — new module: GitHub release fetcher, Apple catalog parser, retry logic, progress callbacks
- `src/osx_proxmox_next/cli.py` — `download` subcommand with `--opencore-only`/`--recovery-only`/`--no-download` flags
- `src/osx_proxmox_next/assets.py` — `downloadable` field on `AssetCheck`
- `src/osx_proxmox_next/app.py` — TUI download integration with worker thread and progress display
- `tests/test_downloader.py` — 24 tests covering all download paths
- `tests/test_cli.py` — 28 CLI tests including edge cases (both exclusive flags, auto-download)
- `tests/test_assets.py`, `tests/test_app_wizard.py` — updated for new fields

## Testing
- [x] 237 tests passing
- [x] 100% line + branch coverage
- [x] Retry logic, partial cleanup, progress callbacks all covered
- [x] Edge cases: both exclusive flags, network errors, missing catalogs