### PR TITLE
feat: add preflight gate step and improve manage VM UX

### DIFF
--- a/src/osx_proxmox_next/preflight.py
+++ b/src/osx_proxmox_next/preflight.py
@@ -32,15 +32,36 @@ def _is_root() -> bool:
         return False
 
 
+_PROXMOX_BINARIES = ("qm", "pvesm", "pvesh", "qemu-img")
+
+_BUILD_BINARIES: dict[str, str] = {
+    "dmg2img": "apt install dmg2img",
+    "sgdisk": "apt install gdisk",
+    "partprobe": "apt install parted",
+    "losetup": "apt install mount",
+    "mkfs.fat": "apt install dosfstools",
+}
+
+
 def run_preflight() -> list[PreflightCheck]:
     checks: list[PreflightCheck] = []
-    for cmd in ("qm", "pvesm", "pvesh", "qemu-img"):
+    for cmd in _PROXMOX_BINARIES:
         binary = _find_binary(cmd)
         checks.append(
             PreflightCheck(
                 name=f"{cmd} available",
                 ok=bool(binary),
                 details=binary or f"{cmd} not found in PATH or common system paths",
+            )
+        )
+
+    for cmd, install_hint in _BUILD_BINARIES.items():
+        binary = _find_binary(cmd)
+        checks.append(
+            PreflightCheck(
+                name=f"{cmd} available",
+                ok=bool(binary),
+                details=binary or f"Not found. Install with: {install_hint}",
             )
         )
 

--- a/tests/test_app_wizard.py
+++ b/tests/test_app_wizard.py
@@ -4,7 +4,7 @@ import time
 from pathlib import Path
 from unittest.mock import patch
 
-from textual.widgets import Button, Input, Static
+from textual.widgets import Button, Checkbox, Input, Static
 
 from osx_proxmox_next import app as app_module
 from osx_proxmox_next.app import NextApp, WizardState
@@ -15,20 +15,39 @@ from osx_proxmox_next.planner import PlanStep
 # ── Helper ──────────────────────────────────────────────────────────
 
 async def _advance_to_step(pilot, app, target_step, monkeypatch=None):
-    """Advance the wizard to the given step by selecting defaults."""
+    """Advance the wizard to the given step by selecting defaults.
+
+    Step layout (6-step wizard):
+      1 = Preflight
+      2 = OS / Manage VMs
+      3 = Storage
+      4 = Config
+      5 = Review & Dry Run
+      6 = Install
+    """
+    # Step 1 → 2: pass preflight
     if target_step >= 2:
+        app.state.preflight_done = True
+        app.state.preflight_ok = True
+        app.query_one("#preflight_next_btn", Button).disabled = False
+        await pilot.click("#preflight_next_btn")
+        await pilot.pause()
+    # Step 2 → 3: select OS
+    if target_step >= 3:
         await pilot.click("#os_sequoia")
         await pilot.pause()
         await pilot.click("#next_btn")
         await pilot.pause()
-    if target_step >= 3:
-        await pilot.click("#next_btn_2")
-        await pilot.pause()
+    # Step 3 → 4: accept default storage
     if target_step >= 4:
+        await pilot.click("#next_btn_3")
+        await pilot.pause()
+    # Step 4 → 5: validate config
+    if target_step >= 5:
         if monkeypatch:
             monkeypatch.setattr(app_module, "required_assets", lambda cfg: [])
             monkeypatch.setattr(app_module, "validate_config", lambda cfg: [])
-        await pilot.click("#next_btn_3")
+        await pilot.click("#next_btn_4")
         await pilot.pause()
 
 
@@ -46,12 +65,12 @@ def test_wizard_starts_at_step1() -> None:
     asyncio.run(_run())
 
 
-def test_next_blocked_without_os_selection() -> None:
+def test_next_blocked_without_preflight() -> None:
     async def _run() -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
-            assert app.query_one("#next_btn", Button).disabled is True
+            assert app.query_one("#preflight_next_btn", Button).disabled is True
             app._go_next()
             assert app.current_step == 1
 
@@ -63,16 +82,23 @@ def test_forward_backward_navigation() -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
-            # Select OS → step 2
+            # Pass preflight → step 2
+            app.state.preflight_done = True
+            app.state.preflight_ok = True
+            app.query_one("#preflight_next_btn", Button).disabled = False
+            await pilot.click("#preflight_next_btn")
+            await pilot.pause()
+            assert app.current_step == 2
+            # Select OS → step 3
             await pilot.click("#os_sequoia")
             await pilot.pause()
             await pilot.click("#next_btn")
             await pilot.pause()
-            assert app.current_step == 2
-            # Back → step 1
-            await pilot.click("#back_btn")
+            assert app.current_step == 3
+            # Back → step 2
+            await pilot.click("#back_btn_3")
             await pilot.pause()
-            assert app.current_step == 1
+            assert app.current_step == 2
 
     asyncio.run(_run())
 
@@ -88,33 +114,30 @@ def test_back_at_step1_stays() -> None:
     asyncio.run(_run())
 
 
-def test_step2_next_without_storage_blocked() -> None:
+def test_step3_next_without_storage_blocked() -> None:
     async def _run() -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
-            await pilot.click("#os_sequoia")
-            await pilot.pause()
-            await pilot.click("#next_btn")
-            await pilot.pause()
+            await _advance_to_step(pilot, app, 3)
             app.state.selected_storage = ""
             app._go_next()
-            assert app.current_step == 2
+            assert app.current_step == 3
 
     asyncio.run(_run())
 
 
-def test_step4_next_requires_dry_run() -> None:
+def test_step5_next_requires_dry_run() -> None:
     async def _run() -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
-            # Force to step 4 directly
-            app.current_step = 4
+            # Force to step 5 directly
+            app.current_step = 5
             await pilot.pause()
             app.state.dry_run_ok = False
             app._go_next()
-            assert app.current_step == 4
+            assert app.current_step == 5
 
     asyncio.run(_run())
 
@@ -125,14 +148,16 @@ def test_step_bar_updates() -> None:
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
             bar_text = app.query_one("#step_bar", Static).content
-            assert "[>] 1.OS" in bar_text
-            await pilot.click("#os_sequoia")
-            await pilot.pause()
-            await pilot.click("#next_btn")
+            assert "[>] 1.Preflight" in bar_text
+            # Pass preflight → step 2
+            app.state.preflight_done = True
+            app.state.preflight_ok = True
+            app.query_one("#preflight_next_btn", Button).disabled = False
+            await pilot.click("#preflight_next_btn")
             await pilot.pause()
             bar_text = app.query_one("#step_bar", Static).content
-            assert "[>] 2.Storage" in bar_text
-            assert "[x] 1.OS" in bar_text
+            assert "[>] 2.OS" in bar_text
+            assert "[x] 1.Preflight" in bar_text
 
     asyncio.run(_run())
 
@@ -142,24 +167,87 @@ def test_step_visibility_toggles() -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
-            app.current_step = 3
+            app.current_step = 4
             await pilot.pause()
-            assert not app.query_one("#step3").has_class("step_hidden")
+            assert not app.query_one("#step4").has_class("step_hidden")
             assert app.query_one("#step1").has_class("step_hidden")
             assert app.query_one("#step2").has_class("step_hidden")
-            assert app.query_one("#step4").has_class("step_hidden")
+            assert app.query_one("#step3").has_class("step_hidden")
             assert app.query_one("#step5").has_class("step_hidden")
+            assert app.query_one("#step6").has_class("step_hidden")
 
     asyncio.run(_run())
 
 
-# ── Step 1: OS Selection ────────────────────────────────────────────
+# ── Step 1: Preflight ─────────────────────────────────────────────
+
+def test_preflight_step_blocks_until_ok() -> None:
+    """Step 1 Continue button is disabled when checks fail."""
+    from osx_proxmox_next.preflight import PreflightCheck
+
+    async def _run() -> None:
+        app = NextApp()
+        async with app.run_test(size=(120, 44)) as pilot:
+            await pilot.pause()
+            checks = [
+                PreflightCheck("qm available", False, "not found"),
+            ]
+            app._finish_preflight(checks)
+            assert app.query_one("#preflight_next_btn", Button).disabled is True
+            app._go_next()
+            assert app.current_step == 1
+
+    asyncio.run(_run())
+
+
+def test_preflight_step_enables_on_success() -> None:
+    """Step 1 Continue enables when all checks pass."""
+    from osx_proxmox_next.preflight import PreflightCheck
+
+    async def _run() -> None:
+        app = NextApp()
+        async with app.run_test(size=(120, 44)) as pilot:
+            await pilot.pause()
+            checks = [
+                PreflightCheck("qm available", True, "/usr/sbin/qm"),
+                PreflightCheck("Root privileges", True, "uid=0"),
+            ]
+            app._finish_preflight(checks)
+            assert app.query_one("#preflight_next_btn", Button).disabled is False
+
+    asyncio.run(_run())
+
+
+def test_rerun_preflight() -> None:
+    """_rerun_preflight resets state and re-disables button."""
+    from osx_proxmox_next.preflight import PreflightCheck
+
+    async def _run() -> None:
+        app = NextApp()
+        async with app.run_test(size=(120, 44)) as pilot:
+            await pilot.pause()
+            # First complete preflight successfully
+            checks = [PreflightCheck("qm available", True, "/usr/sbin/qm")]
+            app._finish_preflight(checks)
+            assert app.state.preflight_ok is True
+            assert app.query_one("#preflight_next_btn", Button).disabled is False
+            # Rerun should reset
+            app._rerun_preflight()
+            assert app.state.preflight_done is False
+            assert app.state.preflight_ok is False
+            assert app.query_one("#preflight_next_btn", Button).disabled is True
+
+    asyncio.run(_run())
+
+
+# ── Step 2: OS Selection ────────────────────────────────────────────
 
 def test_select_os_sonoma() -> None:
     async def _run() -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
+            await _advance_to_step(pilot, app, 2)
             await pilot.click("#os_sonoma")
             await pilot.pause()
             assert app.state.selected_os == "sonoma"
@@ -176,6 +264,7 @@ def test_select_os_sequoia() -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
+            await _advance_to_step(pilot, app, 2)
             await pilot.click("#os_sequoia")
             await pilot.pause()
             assert app.state.selected_os == "sequoia"
@@ -189,6 +278,7 @@ def test_select_os_tahoe() -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
+            await _advance_to_step(pilot, app, 2)
             await pilot.click("#os_tahoe")
             await pilot.pause()
             assert app.state.selected_os == "tahoe"
@@ -202,6 +292,7 @@ def test_switch_os_deselects_previous() -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
+            await _advance_to_step(pilot, app, 2)
             await pilot.click("#os_sonoma")
             await pilot.pause()
             assert app.query_one("#os_sonoma").has_class("os_selected")
@@ -228,7 +319,20 @@ def test_os_invalid_key_ignored() -> None:
     asyncio.run(_run())
 
 
-# ── Step 2: Storage Selection ───────────────────────────────────────
+def test_next_blocked_without_os_selection() -> None:
+    async def _run() -> None:
+        app = NextApp()
+        async with app.run_test(size=(120, 44)) as pilot:
+            await pilot.pause()
+            await _advance_to_step(pilot, app, 2)
+            assert app.query_one("#next_btn", Button).disabled is True
+            app._go_next()
+            assert app.current_step == 2
+
+    asyncio.run(_run())
+
+
+# ── Step 3: Storage Selection ───────────────────────────────────────
 
 def test_storage_preselected() -> None:
     async def _run() -> None:
@@ -245,11 +349,8 @@ def test_storage_click_selects() -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
-            await pilot.click("#os_sequoia")
-            await pilot.pause()
-            await pilot.click("#next_btn")
-            await pilot.pause()
-            assert app.current_step == 2
+            await _advance_to_step(pilot, app, 3)
+            assert app.current_step == 3
             await pilot.click("#storage_0")
             await pilot.pause()
             assert app.state.selected_storage == app.state.storage_targets[0]
@@ -289,10 +390,7 @@ def test_storage_selection_updates_buttons() -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
-            await pilot.click("#os_sequoia")
-            await pilot.pause()
-            await pilot.click("#next_btn")
-            await pilot.pause()
+            await _advance_to_step(pilot, app, 3)
             if len(app.state.storage_targets) >= 2:
                 await pilot.click("#storage_1")
                 await pilot.pause()
@@ -312,14 +410,14 @@ def test_detect_storage_fallback() -> None:
     asyncio.run(_run())
 
 
-# ── Step 3: Configuration ──────────────────────────────────────────
+# ── Step 4: Configuration ──────────────────────────────────────────
 
-def test_prefill_form_on_step2_next() -> None:
+def test_prefill_form_on_step3_next() -> None:
     async def _run() -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
-            await _advance_to_step(pilot, app, 3)
+            await _advance_to_step(pilot, app, 4)
             assert app.query_one("#name", Input).value == "macos-sequoia"
             assert app.query_one("#storage_input", Input).value != ""
 
@@ -331,7 +429,7 @@ def test_suggest_defaults_button() -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
-            await _advance_to_step(pilot, app, 3)
+            await _advance_to_step(pilot, app, 4)
             app.query_one("#vmid", Input).value = ""
             app.query_one("#name", Input).value = ""
             await pilot.click("#suggest_btn")
@@ -347,7 +445,7 @@ def test_generate_smbios_button() -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
-            await _advance_to_step(pilot, app, 3)
+            await _advance_to_step(pilot, app, 4)
             old_serial = app.state.smbios.serial if app.state.smbios else ""
             await pilot.click("#smbios_btn")
             await pilot.pause()
@@ -363,7 +461,7 @@ def test_smbios_preview_none() -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
-            await _advance_to_step(pilot, app, 3)
+            await _advance_to_step(pilot, app, 4)
             app.state.smbios = None
             app._update_smbios_preview()
             await pilot.pause()
@@ -378,7 +476,7 @@ def test_validate_form_all_invalid() -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
-            await _advance_to_step(pilot, app, 3)
+            await _advance_to_step(pilot, app, 4)
             app.query_one("#vmid", Input).value = "abc"
             app.query_one("#name", Input).value = "x"
             app.query_one("#memory", Input).value = "100"
@@ -402,7 +500,7 @@ def test_validate_form_valid() -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
-            await _advance_to_step(pilot, app, 3)
+            await _advance_to_step(pilot, app, 4)
             result = app._validate_form(quiet=True)
             assert result is True
             assert not app.query_one("#vmid", Input).has_class("invalid")
@@ -415,7 +513,7 @@ def test_validate_form_quiet_no_notification() -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
-            await _advance_to_step(pilot, app, 3)
+            await _advance_to_step(pilot, app, 4)
             app.query_one("#vmid", Input).value = "abc"
             result = app._validate_form(quiet=True)
             assert result is False
@@ -428,7 +526,7 @@ def test_input_changed_triggers_validation() -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
-            await _advance_to_step(pilot, app, 3)
+            await _advance_to_step(pilot, app, 4)
             app.query_one("#vmid", Input).value = "5"
             await pilot.pause()
             assert app.query_one("#vmid", Input).has_class("invalid")
@@ -436,49 +534,49 @@ def test_input_changed_triggers_validation() -> None:
     asyncio.run(_run())
 
 
-def test_step3_next_validation_blocks() -> None:
+def test_step4_next_validation_blocks() -> None:
     async def _run() -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
-            await _advance_to_step(pilot, app, 3)
+            await _advance_to_step(pilot, app, 4)
             app.query_one("#vmid", Input).value = "abc"
-            await pilot.click("#next_btn_3")
+            await pilot.click("#next_btn_4")
             await pilot.pause()
-            assert app.current_step == 3
+            assert app.current_step == 4
 
     asyncio.run(_run())
 
 
-def test_step3_next_read_form_fails() -> None:
+def test_step4_next_read_form_fails() -> None:
     async def _run() -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
-            await _advance_to_step(pilot, app, 3)
+            await _advance_to_step(pilot, app, 4)
             # Make _validate_form pass but _read_form fail
             from unittest.mock import patch
             with patch.object(app, "_validate_form", return_value=True):
                 with patch.object(app, "_read_form", return_value=None):
                     app._go_next()
-            assert app.current_step == 3
+            assert app.current_step == 4
 
     asyncio.run(_run())
 
 
-def test_step3_next_domain_validation_fails(monkeypatch) -> None:
+def test_step4_next_domain_validation_fails(monkeypatch) -> None:
     async def _run() -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
-            await _advance_to_step(pilot, app, 3)
+            await _advance_to_step(pilot, app, 4)
             monkeypatch.setattr(
                 app_module, "validate_config",
                 lambda cfg: ["Fake domain error."],
             )
-            await pilot.click("#next_btn_3")
+            await pilot.click("#next_btn_4")
             await pilot.pause()
-            assert app.current_step == 3
+            assert app.current_step == 4
             errors_text = str(app.query_one("#form_errors", Static).content)
             assert "Fake domain error" in errors_text
 
@@ -490,7 +588,7 @@ def test_read_form_invalid_vmid() -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
-            await _advance_to_step(pilot, app, 3)
+            await _advance_to_step(pilot, app, 4)
             app.query_one("#vmid", Input).value = "not-a-number"
             result = app._read_form()
             assert result is None
@@ -503,7 +601,7 @@ def test_read_form_success() -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
-            await _advance_to_step(pilot, app, 3)
+            await _advance_to_step(pilot, app, 4)
             config = app._read_form()
             assert config is not None
             assert config.macos == "sequoia"
@@ -517,7 +615,7 @@ def test_read_form_no_smbios() -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
-            await _advance_to_step(pilot, app, 3)
+            await _advance_to_step(pilot, app, 4)
             app.state.smbios = None
             config = app._read_form()
             assert config is not None
@@ -526,34 +624,42 @@ def test_read_form_no_smbios() -> None:
     asyncio.run(_run())
 
 
-def test_preflight_badge_running() -> None:
+def test_preflight_checks_running() -> None:
     async def _run() -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
             app.state.preflight_done = False
-            app._update_preflight_badge()
-            text = str(app.query_one("#preflight_badge", Static).content)
-            assert "running" in text
+            app._update_preflight_display()
+            text = str(app.query_one("#preflight_checks", Static).content)
+            assert "Checking" in text
 
     asyncio.run(_run())
 
 
-def test_preflight_badge_ok() -> None:
+def test_preflight_checks_ok() -> None:
+    from osx_proxmox_next.preflight import PreflightCheck
+
     async def _run() -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
             app.state.preflight_done = True
             app.state.preflight_ok = True
-            app._update_preflight_badge()
-            text = str(app.query_one("#preflight_badge", Static).content)
-            assert "Host Ready" in text
+            app.state.preflight_checks = [
+                PreflightCheck("qm available", True, "/usr/sbin/qm"),
+                PreflightCheck("dmg2img available", True, "/usr/bin/dmg2img"),
+            ]
+            app._update_preflight_display()
+            text = str(app.query_one("#preflight_checks", Static).content)
+            assert "All 2 checks passed" in text
+            assert "qm available" in text
+            assert "dmg2img available" in text
 
     asyncio.run(_run())
 
 
-def test_preflight_badge_failed() -> None:
+def test_preflight_checks_failed() -> None:
     from osx_proxmox_next.preflight import PreflightCheck
 
     async def _run() -> None:
@@ -564,26 +670,50 @@ def test_preflight_badge_failed() -> None:
             app.state.preflight_ok = False
             app.state.preflight_checks = [
                 PreflightCheck("qm available", False, "not found"),
-                PreflightCheck("Root privileges", False, "not root"),
+                PreflightCheck("dmg2img available", False, "Not found. Install with: apt install dmg2img"),
             ]
-            app._update_preflight_badge()
-            text = str(app.query_one("#preflight_badge", Static).content)
-            assert "2 checks failed" in text
+            app._update_preflight_display()
+            text = str(app.query_one("#preflight_checks", Static).content)
+            assert "2 check(s) failed" in text
+            assert "qm available: not found" in text
+            assert "apt install dmg2img" in text
 
     asyncio.run(_run())
 
 
-# ── Step 4: Review & Dry Run ───────────────────────────────────────
+def test_preflight_checks_mixed() -> None:
+    from osx_proxmox_next.preflight import PreflightCheck
 
-def test_step3_to_step4_with_assets_ok(monkeypatch) -> None:
+    async def _run() -> None:
+        app = NextApp()
+        async with app.run_test(size=(120, 44)) as pilot:
+            await pilot.pause()
+            app.state.preflight_done = True
+            app.state.preflight_ok = False
+            app.state.preflight_checks = [
+                PreflightCheck("qm available", True, "/usr/sbin/qm"),
+                PreflightCheck("dmg2img available", False, "Not found. Install with: apt install dmg2img"),
+            ]
+            app._update_preflight_display()
+            text = str(app.query_one("#preflight_checks", Static).content)
+            assert "1 check(s) failed" in text
+            assert "qm available" in text
+            assert "dmg2img available" in text
+
+    asyncio.run(_run())
+
+
+# ── Step 5: Review & Dry Run ───────────────────────────────────────
+
+def test_step4_to_step5_with_assets_ok(monkeypatch) -> None:
     monkeypatch.setattr(app_module, "required_assets", lambda cfg: [])
 
     async def _run() -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
-            await _advance_to_step(pilot, app, 4, monkeypatch)
-            assert app.current_step == 4
+            await _advance_to_step(pilot, app, 5, monkeypatch)
+            assert app.current_step == 5
             assert app.state.assets_ok is True
             assert app.query_one("#dry_run_btn", Button).disabled is False
 
@@ -597,7 +727,7 @@ def test_config_summary_displayed(monkeypatch) -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
-            await _advance_to_step(pilot, app, 4, monkeypatch)
+            await _advance_to_step(pilot, app, 5, monkeypatch)
             summary = str(app.query_one("#config_summary", Static).content)
             assert "Sequoia" in summary or "sequoia" in summary
             assert "Create VM shell" in summary
@@ -612,10 +742,10 @@ def test_config_summary_with_installer_path(monkeypatch) -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
-            await _advance_to_step(pilot, app, 3)
+            await _advance_to_step(pilot, app, 4)
             app.query_one("#installer_path", Input).value = "/tmp/test.iso"
             monkeypatch.setattr(app_module, "validate_config", lambda cfg: [])
-            await pilot.click("#next_btn_3")
+            await pilot.click("#next_btn_4")
             await pilot.pause()
             summary = str(app.query_one("#config_summary", Static).content)
             assert "Installer" in summary
@@ -644,12 +774,12 @@ def test_check_assets_missing_not_downloadable(monkeypatch) -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
-            await _advance_to_step(pilot, app, 3)
+            await _advance_to_step(pilot, app, 4)
             monkeypatch.setattr(
                 app_module, "required_assets",
                 lambda cfg: [AssetCheck("OC", Path("/tmp/oc.iso"), False, "missing", downloadable=False)],
             )
-            await pilot.click("#next_btn_3")
+            await pilot.click("#next_btn_4")
             await pilot.pause()
             status = str(app.query_one("#download_status", Static).content)
             assert "Provide path manually" in status
@@ -696,8 +826,8 @@ def test_download_worker_success(monkeypatch) -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
-            await _advance_to_step(pilot, app, 3)
-            # Set required_assets AFTER _advance_to_step (which doesn't use it for step 3)
+            await _advance_to_step(pilot, app, 4)
+            # Set required_assets AFTER _advance_to_step (which doesn't use it for step 4)
             monkeypatch.setattr(
                 app_module, "required_assets",
                 lambda cfg: [
@@ -705,7 +835,7 @@ def test_download_worker_success(monkeypatch) -> None:
                     AssetCheck("Installer / recovery image", Path("/tmp/rec.iso"), False, "", downloadable=True),
                 ],
             )
-            await pilot.click("#next_btn_3")
+            await pilot.click("#next_btn_4")
             await pilot.pause()
             for _ in range(30):
                 await pilot.pause()
@@ -733,14 +863,14 @@ def test_download_worker_opencore_error(monkeypatch) -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
-            await _advance_to_step(pilot, app, 3)
+            await _advance_to_step(pilot, app, 4)
             monkeypatch.setattr(
                 app_module, "required_assets",
                 lambda cfg: [
                     AssetCheck("OpenCore image", Path("/tmp/oc.iso"), False, "", downloadable=True),
                 ],
             )
-            await pilot.click("#next_btn_3")
+            await pilot.click("#next_btn_4")
             await pilot.pause()
             for _ in range(30):
                 await pilot.pause()
@@ -768,14 +898,14 @@ def test_download_worker_recovery_error(monkeypatch) -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
-            await _advance_to_step(pilot, app, 3)
+            await _advance_to_step(pilot, app, 4)
             monkeypatch.setattr(
                 app_module, "required_assets",
                 lambda cfg: [
                     AssetCheck("Installer / recovery image", Path("/tmp/rec.iso"), False, "", downloadable=True),
                 ],
             )
-            await pilot.click("#next_btn_3")
+            await pilot.click("#next_btn_4")
             await pilot.pause()
             for _ in range(30):
                 await pilot.pause()
@@ -877,7 +1007,7 @@ def test_dry_run_success(monkeypatch) -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
-            await _advance_to_step(pilot, app, 4, monkeypatch)
+            await _advance_to_step(pilot, app, 5, monkeypatch)
             await pilot.click("#dry_run_btn")
             for _ in range(30):
                 await pilot.pause()
@@ -885,7 +1015,7 @@ def test_dry_run_success(monkeypatch) -> None:
                 if not app.state.apply_running:
                     break
             assert app.state.dry_run_ok is True
-            assert app.query_one("#next_btn_4", Button).disabled is False
+            assert app.query_one("#next_btn_5", Button).disabled is False
 
     asyncio.run(_run())
 
@@ -903,7 +1033,7 @@ def test_dry_run_failure(monkeypatch) -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
-            await _advance_to_step(pilot, app, 4, monkeypatch)
+            await _advance_to_step(pilot, app, 5, monkeypatch)
             await pilot.click("#dry_run_btn")
             for _ in range(30):
                 await pilot.pause()
@@ -949,7 +1079,7 @@ def test_update_dry_progress_after_result() -> None:
     asyncio.run(_run())
 
 
-# ── Step 5: Install ────────────────────────────────────────────────
+# ── Step 6: Install ────────────────────────────────────────────────
 
 def test_prepare_install_step() -> None:
     from osx_proxmox_next.domain import VmConfig
@@ -1417,6 +1547,7 @@ def test_finish_preflight_all_ok(monkeypatch) -> None:
             ]
             app._finish_preflight(checks)
             assert app.state.preflight_ok is True
+            assert app.query_one("#preflight_next_btn", Button).disabled is False
 
     asyncio.run(_run())
 
@@ -1434,6 +1565,7 @@ def test_finish_preflight_some_fail(monkeypatch) -> None:
             ]
             app._finish_preflight(checks)
             assert app.state.preflight_ok is False
+            assert app.query_one("#preflight_next_btn", Button).disabled is True
 
     asyncio.run(_run())
 
@@ -1509,7 +1641,7 @@ def test_suggest_defaults_generates_smbios_if_missing() -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
-            await _advance_to_step(pilot, app, 3)
+            await _advance_to_step(pilot, app, 4)
             app.state.smbios = None
             app._apply_host_defaults()
             assert app.state.smbios is not None
@@ -1522,7 +1654,7 @@ def test_suggest_defaults_keeps_existing_smbios() -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
-            await _advance_to_step(pilot, app, 3)
+            await _advance_to_step(pilot, app, 4)
             original = app.state.smbios
             app._apply_host_defaults()
             assert app.state.smbios is original
@@ -1530,22 +1662,22 @@ def test_suggest_defaults_keeps_existing_smbios() -> None:
     asyncio.run(_run())
 
 
-def test_go_next_step5_noop() -> None:
-    """_go_next at step 5 does nothing (no step 6)."""
+def test_go_next_step6_noop() -> None:
+    """_go_next at step 6 does nothing (no step 7)."""
     async def _run() -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
-            app.current_step = 5
+            app.current_step = 6
             await pilot.pause()
             app._go_next()
-            assert app.current_step == 5
+            assert app.current_step == 6
 
     asyncio.run(_run())
 
 
-def test_step4_to_step5_transition(monkeypatch) -> None:
-    """Dry run OK → Next: Install transitions to step 5."""
+def test_step5_to_step6_transition(monkeypatch) -> None:
+    """Dry run OK -> Next: Install transitions to step 6."""
     from osx_proxmox_next.domain import VmConfig
 
     monkeypatch.setattr(app_module, "required_assets", lambda cfg: [])
@@ -1555,13 +1687,13 @@ def test_step4_to_step5_transition(monkeypatch) -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
-            await _advance_to_step(pilot, app, 4, monkeypatch)
+            await _advance_to_step(pilot, app, 5, monkeypatch)
             # Simulate dry run passing
             app.state.dry_run_ok = True
-            app.query_one("#next_btn_4", Button).disabled = False
-            await pilot.click("#next_btn_4")
+            app.query_one("#next_btn_5", Button).disabled = False
+            await pilot.click("#next_btn_5")
             await pilot.pause()
-            assert app.current_step == 5
+            assert app.current_step == 6
             label = str(app.query_one("#install_btn", Button).label)
             assert "Sequoia" in label
 
@@ -1586,7 +1718,7 @@ def test_download_worker_skips_non_downloadable(monkeypatch) -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
-            await _advance_to_step(pilot, app, 3)
+            await _advance_to_step(pilot, app, 4)
             # Mix of downloadable and non-downloadable
             monkeypatch.setattr(
                 app_module, "required_assets",
@@ -1595,7 +1727,7 @@ def test_download_worker_skips_non_downloadable(monkeypatch) -> None:
                     AssetCheck("Extra thing", Path("/tmp/extra"), False, "", downloadable=False),
                 ],
             )
-            await pilot.click("#next_btn_3")
+            await pilot.click("#next_btn_4")
             await pilot.pause()
             for _ in range(30):
                 await pilot.pause()
@@ -1615,7 +1747,7 @@ def test_rebuild_plan_after_download(monkeypatch) -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
-            await _advance_to_step(pilot, app, 4, monkeypatch)
+            await _advance_to_step(pilot, app, 5, monkeypatch)
             assert app.state.plan_steps
             old_steps = list(app.state.plan_steps)
             # Simulate a rebuild
@@ -1634,7 +1766,7 @@ def test_rebuild_plan_after_download_no_config(monkeypatch) -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
-            await _advance_to_step(pilot, app, 4, monkeypatch)
+            await _advance_to_step(pilot, app, 5, monkeypatch)
             old_config = app.state.config
             # Break the form so _read_form returns None
             app.query_one("#vmid", Input).value = "invalid"
@@ -1653,6 +1785,7 @@ def test_manage_mode_toggle() -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
+            await _advance_to_step(pilot, app, 2)
             assert not app.state.manage_mode
             assert not app.query_one("#create_panel").has_class("hidden")
             assert app.query_one("#manage_panel").has_class("hidden")
@@ -1677,7 +1810,17 @@ def test_manage_mode_toggle() -> None:
 def test_manage_vm_list_populated(monkeypatch) -> None:
     def fake_check_output(cmd, **kw):
         if cmd[0] == "qm" and cmd[1] == "list":
-            return "VMID  NAME          STATUS\n106   macos-test    running\n200   macos-dev     stopped\n"
+            return (
+                "VMID  NAME          STATUS\n"
+                "106   macos-test    running\n"
+                "\n"
+                "200   linux-vm      stopped\n"
+            )
+        if cmd[0] == "qm" and cmd[1] == "config":
+            vmid = cmd[2]
+            if vmid == "106":
+                return 'args: -device isa-applesmc,osk="test"\n'
+            return "ostype: l26\n"  # non-macOS
         raise Exception("not found")
 
     monkeypatch.setattr(app_module, "check_output", fake_check_output)
@@ -1686,6 +1829,7 @@ def test_manage_vm_list_populated(monkeypatch) -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
+            await _advance_to_step(pilot, app, 2)
             await pilot.click("#mode_manage")
             for _ in range(20):
                 await pilot.pause()
@@ -1695,6 +1839,8 @@ def test_manage_vm_list_populated(monkeypatch) -> None:
             display = str(app.query_one("#vm_list_display", Static).content)
             assert "106" in display
             assert "macos-test" in display
+            assert "200" not in display
+            assert "linux-vm" not in display
 
     asyncio.run(_run())
 
@@ -1709,12 +1855,64 @@ def test_manage_vm_list_empty(monkeypatch) -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
+            await _advance_to_step(pilot, app, 2)
             await pilot.click("#mode_manage")
             for _ in range(20):
                 await pilot.pause()
                 time.sleep(0.05)
             display = str(app.query_one("#vm_list_display", Static).content)
-            assert "No VMs found" in display
+            assert "No macOS VMs found" in display
+
+    asyncio.run(_run())
+
+
+def test_manage_vm_list_no_macos_vms(monkeypatch) -> None:
+    def fake_check_output(cmd, **kw):
+        if cmd[0] == "qm" and cmd[1] == "list":
+            return "VMID  NAME          STATUS\n200   linux-vm      running\n"
+        if cmd[0] == "qm" and cmd[1] == "config":
+            return "ostype: l26\n"
+        raise Exception("not found")
+
+    monkeypatch.setattr(app_module, "check_output", fake_check_output)
+
+    async def _run() -> None:
+        app = NextApp()
+        async with app.run_test(size=(120, 44)) as pilot:
+            await pilot.pause()
+            await _advance_to_step(pilot, app, 2)
+            await pilot.click("#mode_manage")
+            for _ in range(20):
+                await pilot.pause()
+                time.sleep(0.05)
+            display = str(app.query_one("#vm_list_display", Static).content)
+            assert "No macOS VMs found" in display
+
+    asyncio.run(_run())
+
+
+def test_manage_vm_list_config_failure(monkeypatch) -> None:
+    def fake_check_output(cmd, **kw):
+        if cmd[0] == "qm" and cmd[1] == "list":
+            return "VMID  NAME          STATUS\n106   macos-test    running\n"
+        if cmd[0] == "qm" and cmd[1] == "config":
+            raise Exception("config failed")
+        raise Exception("not found")
+
+    monkeypatch.setattr(app_module, "check_output", fake_check_output)
+
+    async def _run() -> None:
+        app = NextApp()
+        async with app.run_test(size=(120, 44)) as pilot:
+            await pilot.pause()
+            await _advance_to_step(pilot, app, 2)
+            await pilot.click("#mode_manage")
+            for _ in range(20):
+                await pilot.pause()
+                time.sleep(0.05)
+            display = str(app.query_one("#vm_list_display", Static).content)
+            # Config failed → VM skipped → no macOS VMs
+            assert "No macOS VMs found" in display
 
     asyncio.run(_run())
 
@@ -1724,6 +1922,7 @@ def test_manage_vmid_input_enables_destroy() -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
+            await _advance_to_step(pilot, app, 2)
             await pilot.click("#mode_manage")
             await pilot.pause()
             assert app.query_one("#manage_destroy_btn", Button).disabled is True
@@ -1739,6 +1938,7 @@ def test_manage_vmid_invalid_keeps_destroy_disabled() -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
+            await _advance_to_step(pilot, app, 2)
             await pilot.click("#mode_manage")
             await pilot.pause()
             app.query_one("#manage_vmid", Input).value = "abc"
@@ -1753,6 +1953,7 @@ def test_manage_vmid_out_of_range() -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
+            await _advance_to_step(pilot, app, 2)
             await pilot.click("#mode_manage")
             await pilot.pause()
             app.query_one("#manage_vmid", Input).value = "5"
@@ -1767,20 +1968,27 @@ def test_manage_purge_toggle() -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
+            await _advance_to_step(pilot, app, 2)
             await pilot.click("#mode_manage")
             await pilot.pause()
             assert app.state.uninstall_purge is True
-            assert "ON" in str(app.query_one("#manage_purge_btn", Button).label)
-            # Toggle OFF
-            app._toggle_purge()
+            cb = app.query_one("#manage_purge_cb", Checkbox)
+            assert cb.value is True
+            # Toggle OFF via click (fires on_checkbox_changed)
+            await pilot.click("#manage_purge_cb")
             await pilot.pause()
+            assert cb.value is False
             assert app.state.uninstall_purge is False
-            assert "OFF" in str(app.query_one("#manage_purge_btn", Button).label)
             # Toggle back ON
-            app._toggle_purge()
+            await pilot.click("#manage_purge_cb")
             await pilot.pause()
+            assert cb.value is True
             assert app.state.uninstall_purge is True
-            assert "ON" in str(app.query_one("#manage_purge_btn", Button).label)
+            # Cover else branch: unknown checkbox ID is ignored
+            fake_cb = Checkbox("fake", id="other_cb")
+            event = Checkbox.Changed(fake_cb, fake_cb.value)
+            app.on_checkbox_changed(event)
+            assert app.state.uninstall_purge is True  # unchanged
 
     asyncio.run(_run())
 
@@ -1802,6 +2010,7 @@ def test_manage_destroy_invalid_vmid_noop() -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
+            await _advance_to_step(pilot, app, 2)
             await pilot.click("#mode_manage")
             await pilot.pause()
             app.query_one("#manage_vmid", Input).value = "abc"
@@ -1816,6 +2025,7 @@ def test_manage_destroy_vmid_out_of_range_noop() -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
+            await _advance_to_step(pilot, app, 2)
             await pilot.click("#mode_manage")
             await pilot.pause()
             app.query_one("#manage_vmid", Input).value = "50"
@@ -1849,6 +2059,7 @@ def test_manage_destroy_success(monkeypatch) -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
+            await _advance_to_step(pilot, app, 2)
             await pilot.click("#mode_manage")
             await pilot.pause()
             app.query_one("#manage_vmid", Input).value = "106"
@@ -1884,6 +2095,7 @@ def test_manage_destroy_failure(monkeypatch) -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
+            await _advance_to_step(pilot, app, 2)
             await pilot.click("#mode_manage")
             await pilot.pause()
             app.query_one("#manage_vmid", Input).value = "106"
@@ -1896,7 +2108,7 @@ def test_manage_destroy_failure(monkeypatch) -> None:
                     break
             assert app.state.uninstall_ok is False
             result_text = str(app.query_one("#manage_result", Static).content)
-            assert "FAILED" in result_text
+            assert "Failed" in result_text
 
     asyncio.run(_run())
 
@@ -1906,6 +2118,7 @@ def test_manage_update_destroy_log() -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
+            await _advance_to_step(pilot, app, 2)
             await pilot.click("#mode_manage")
             await pilot.pause()
             app.query_one("#manage_log").remove_class("hidden")
@@ -1930,6 +2143,7 @@ def test_manage_finish_destroy_refreshes_list(monkeypatch) -> None:
         app = NextApp()
         async with app.run_test(size=(120, 44)) as pilot:
             await pilot.pause()
+            await _advance_to_step(pilot, app, 2)
             await pilot.click("#mode_manage")
             await pilot.pause()
             app.query_one("#manage_vmid", Input).value = "106"
@@ -1950,5 +2164,3 @@ def test_wizard_state_manage_defaults() -> None:
     assert state.uninstall_running is False
     assert state.uninstall_done is False
     assert state.uninstall_ok is False
-
-


### PR DESCRIPTION
## Summary
- Preflight checks are now step 1 of the wizard, blocking all navigation until all checks pass
- Added build dependency checks (dmg2img, sgdisk, partprobe, losetup, mkfs.fat) with install instructions
- Improved manage VM UX: checkbox for purge toggle, fixed label alignment, macOS-only VM filter

## Changes
- `preflight.py`: added `_BUILD_BINARIES` dict with 5 build deps and install hints
- `app.py`: 6-step wizard (Preflight → OS → Storage → Config → Dry Run → Install), checkbox widget, `isa-applesmc` VM filtering
- Tests: 295 passing, 100% coverage

## Test plan
- [x] All 295 tests pass
- [x] 100% branch coverage
- [x] Deployed and tested on pve-mirna

Closes #9