### PR TITLE
chore: mark Tahoe as stable and add community-scripts section

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,16 @@ This clones the repo, sets up a Python venv, and launches the TUI wizard.
 
 > Built solo and maintained in my free time. If it saves you an afternoon of `qm` commands, [a coffee helps](https://ko-fi.com/lucidfabrics) or a [coffee on BMC](https://buymeacoffee.com/lucidfabrics). ☕
 
+### 🐚 Bash Alternative (community-scripts)
+
+Prefer a standalone bash script with no Python dependency? Use the [community-scripts](https://github.com/community-scripts/ProxmoxVE) version:
+
+```bash
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/vm/macos-vm.sh)"
+```
+
+Same VM creation logic (OpenCore + osrecovery + SMBIOS), whiptail menus, no venv needed.
+
 ### 🪄 Wizard Walkthrough
 
 | Step | What Happens |
@@ -128,7 +138,7 @@ Look for `constant_tsc` and `nonstop_tsc` in the output.
 |-------|---------|-------|
 | **Sonoma 14** | ✅ Stable | Best tested, most reliable |
 | **Sequoia 15** | ✅ Stable | Fully supported |
-| **Tahoe 26** | 🧪 Preview | Uses recovery image via osrecovery (auto-downloaded) |
+| **Tahoe 26** | ✅ Stable | Fully supported |
 
 ---
 

--- a/src/osx_proxmox_next/domain.py
+++ b/src/osx_proxmox_next/domain.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 SUPPORTED_MACOS = {
     "sonoma": {"label": "macOS Sonoma 14", "major": 14, "channel": "stable"},
     "sequoia": {"label": "macOS Sequoia 15", "major": 15, "channel": "stable"},
-    "tahoe": {"label": "macOS Tahoe 26", "major": 26, "channel": "preview"},
+    "tahoe": {"label": "macOS Tahoe 26", "major": 26, "channel": "stable"},
 }
 
 

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -29,12 +29,11 @@ def test_build_plan_includes_core_steps() -> None:
     assert any(step.command.startswith("qm start") for step in steps)
 
 
-def test_build_plan_marks_tahoe_preview() -> None:
+def test_build_plan_tahoe_no_preview_warning() -> None:
     cfg = _cfg("tahoe")
     cfg.installer_path = "/tmp/tahoe.iso"
     steps = build_plan(cfg)
-    assert steps[0].title == "Preview warning"
-    assert steps[0].risk == "warn"
+    assert steps[0].title != "Preview warning"
 
 
 def test_render_script_contains_metadata() -> None:


### PR DESCRIPTION
## Summary
- Mark Tahoe 26 as stable (no longer preview) across domain, tests, and README
- Add community-scripts bash alternative section to README Quick Start

## Changes
- `domain.py`: Tahoe channel `preview` → `stable`
- `README.md`: Version table updated, added bash one-liner for community-scripts
- `tests/test_planner.py`: Remove preview warning assertion for Tahoe
- Resolved merge conflicts from v0.5.0

## Test plan
- [x] All 27 tests pass
- [x] No merge conflict markers remain