### PR TITLE
feat: add AMD CPU support with automatic vendor detection

### DIFF
--- a/src/osx_proxmox_next/defaults.py
+++ b/src/osx_proxmox_next/defaults.py
@@ -8,6 +8,18 @@ DEFAULT_STORAGE = "local-lvm"
 DEFAULT_BRIDGE = "vmbr0"
 
 
+def detect_cpu_vendor() -> str:
+    """Return 'AMD' or 'Intel' based on /proc/cpuinfo (default: Intel)."""
+    cpuinfo = Path("/proc/cpuinfo")
+    if cpuinfo.exists():
+        for line in cpuinfo.read_text(encoding="utf-8", errors="ignore").splitlines():
+            if line.startswith("vendor_id"):
+                if "AuthenticAMD" in line:
+                    return "AMD"
+                return "Intel"
+    return "Intel"
+
+
 def detect_cpu_cores() -> int:
     count = os.cpu_count() or 4
     # Keep host responsive and avoid overcommit by default.

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -1,5 +1,5 @@
 from osx_proxmox_next.domain import VmConfig
-from osx_proxmox_next.planner import build_plan, render_script, VmInfo, fetch_vm_info, build_destroy_plan
+from osx_proxmox_next.planner import build_plan, render_script, _cpu_args, VmInfo, fetch_vm_info, build_destroy_plan
 from osx_proxmox_next.infrastructure import CommandResult
 
 
@@ -196,6 +196,47 @@ def test_render_script_simple() -> None:
     assert "#!/usr/bin/env bash" in script
     assert "qm create 901" in script
     assert "Build OpenCore boot disk" in script
+
+
+# ── CPU Vendor Detection Tests ─────────────────────────────────────
+
+
+def test_cpu_args_intel(monkeypatch) -> None:
+    import osx_proxmox_next.planner as planner
+    monkeypatch.setattr(planner, "detect_cpu_vendor", lambda: "Intel")
+    args = _cpu_args()
+    assert "-cpu host," in args
+    assert "vendor=GenuineIntel" in args
+    assert "+kvm_pv_unhalt" in args
+    assert "vmware-cpuid-freq=on" in args
+
+
+def test_cpu_args_amd(monkeypatch) -> None:
+    import osx_proxmox_next.planner as planner
+    monkeypatch.setattr(planner, "detect_cpu_vendor", lambda: "AMD")
+    args = _cpu_args()
+    assert "Haswell-noTSX" in args
+    assert "vendor=GenuineIntel" in args
+    assert "vmware-cpuid-freq=on" in args
+    assert "host" not in args
+
+
+def test_build_plan_amd_uses_haswell(monkeypatch) -> None:
+    import osx_proxmox_next.planner as planner
+    monkeypatch.setattr(planner, "detect_cpu_vendor", lambda: "AMD")
+    steps = build_plan(_cfg("sequoia"))
+    profile = next(step for step in steps if step.title == "Apply macOS hardware profile")
+    assert "Haswell-noTSX" in profile.command
+    assert "vendor=GenuineIntel" in profile.command
+
+
+def test_build_plan_intel_uses_host(monkeypatch) -> None:
+    import osx_proxmox_next.planner as planner
+    monkeypatch.setattr(planner, "detect_cpu_vendor", lambda: "Intel")
+    steps = build_plan(_cfg("sequoia"))
+    profile = next(step for step in steps if step.title == "Apply macOS hardware profile")
+    assert "-cpu host," in profile.command
+    assert "vendor=GenuineIntel" in profile.command
 
 
 # ── Destroy Plan Tests ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Detects AMD vs Intel via `/proc/cpuinfo` at plan time
- AMD hosts use `-cpu Haswell-noTSX` (emulated Intel) instead of `-cpu host` which macOS can't boot on AMD
- Intel hosts keep `-cpu host` with paravirt hints, adds `vmware-cpuid-freq=on` to both
- Based on community fix from #12

## Changes
- `defaults.py`: new `detect_cpu_vendor()` function
- `planner.py`: new `_cpu_args()` helper, dynamic CPU flag in hardware profile step
- `test_defaults.py`: AMD/Intel/missing cpuinfo tests
- `test_planner.py`: AMD Haswell-noTSX and Intel host CPU tests

## Test plan
- [x] All 42+ unit tests pass
- [ ] Manual test on AMD host (pve-tirsa)
- [ ] Manual test on Intel host (existing setup)

Closes #12