### PR TITLE
fix: use blkid to detect FAT32 partition in OpenCore ISO mount

### DIFF
--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -145,6 +145,9 @@ def test_build_plan_includes_build_oc_step() -> None:
     assert "Build OpenCore boot disk" in titles
     build = next(step for step in steps if step.title == "Build OpenCore boot disk")
     assert "losetup" in build.command
+    assert "blkid" in build.command
+    assert "vfat" in build.command
+    assert "SRC_PART" in build.command
     assert "ScanPolicy" in build.command
     assert "DmgLoading" in build.command
     assert "sgdisk" in build.command


### PR DESCRIPTION
## Summary
Replaces positional partition guessing with filesystem-type detection using `blkid`. The previous approach tried `${LOOP}p1` first and fell back to the raw device — failing silently when the FAT32 partition isn't on slot 1 (e.g. GPT ISOs with a protective p1 and data on p2).

## Changes
- Use `blkid` to probe all loop partition nodes and select the one with `TYPE=vfat`
- Add `partprobe` + `sleep 1` before probing to ensure kernel partition device nodes are ready
- Fallback to raw device mount if no vfat partition is found (preserves raw FAT32 ISO support)
- Add stale mount/loop cleanup before the build script runs
- Update test assertions to verify `blkid`/`vfat`/`SRC_PART` are present in the generated script

## Handled layouts
| ISO layout | Before | After |
|------------|--------|-------|
| Raw FAT32 (no partition table) | ✓ | ✓ |
| MBR with FAT32 on p1 | ✓ | ✓ |
| GPT with protective p1, FAT32 on p2 | ✗ | ✓ |
| Any other partition slot | ✗ | ✓ |