### PR TITLE
fix: default SMBIOS model to MacPro7,1 for OCLP compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ osx-next-cli apply --execute \
   --cores 8 --memory 16384 --disk 128 \
   --bridge vmbr0 --storage local-lvm \
   --smbios-serial C02X1234ABCD --smbios-uuid "$(uuidgen)" \
-  --smbios-model iMacPro1,1
+  --smbios-model MacPro7,1
 ```
 
 ---

--- a/scripts/bash/osx-proxmox-next.sh
+++ b/scripts/bash/osx-proxmox-next.sh
@@ -74,9 +74,9 @@ declare -A MACOS_OS_TYPE=(
   ["tahoe"]="latest"
 )
 declare -A SMBIOS_MODELS=(
-  ["ventura"]="iMacPro1,1"
-  ["sonoma"]="iMacPro1,1"
-  ["sequoia"]="iMacPro1,1"
+  ["ventura"]="MacPro7,1"
+  ["sonoma"]="MacPro7,1"
+  ["sequoia"]="MacPro7,1"
   ["tahoe"]="MacPro7,1"
 )
 
@@ -310,7 +310,7 @@ function generate_smbios() {
   SMBIOS_MLB=$(cat /dev/urandom | tr -dc 'A-Z0-9' | head -c 17)
   SMBIOS_ROM=$(openssl rand -hex 6 | tr '[:lower:]' '[:upper:]')
   SMBIOS_UUID=$(cat /proc/sys/kernel/random/uuid | tr '[:lower:]' '[:upper:]')
-  SMBIOS_MODEL="${SMBIOS_MODELS[$macos_ver]:-iMacPro1,1}"
+  SMBIOS_MODEL="${SMBIOS_MODELS[$macos_ver]:-MacPro7,1}"
 }
 
 # ── Download macOS recovery via Apple's osrecovery API ──

--- a/src/osx_proxmox_next/smbios.py
+++ b/src/osx_proxmox_next/smbios.py
@@ -6,13 +6,13 @@ import uuid
 from dataclasses import dataclass
 
 SMBIOS_MODELS: dict[str, str] = {
-    "ventura": "iMacPro1,1",
-    "sonoma": "iMacPro1,1",
-    "sequoia": "iMacPro1,1",
+    "ventura": "MacPro7,1",
+    "sonoma": "MacPro7,1",
+    "sequoia": "MacPro7,1",
     "tahoe": "MacPro7,1",
 }
 
-DEFAULT_SMBIOS_MODEL = "iMacPro1,1"
+DEFAULT_SMBIOS_MODEL = "MacPro7,1"
 
 
 @dataclass

--- a/tests/test_app_wizard.py
+++ b/tests/test_app_wizard.py
@@ -252,7 +252,7 @@ def test_select_os_sonoma() -> None:
             await pilot.pause()
             assert app.state.selected_os == "sonoma"
             assert app.state.smbios is not None
-            assert app.state.smbios.model == "iMacPro1,1"
+            assert app.state.smbios.model == "MacPro7,1"
             assert app.query_one("#os_sonoma").has_class("os_selected")
             assert not app.query_one("#os_sequoia").has_class("os_selected")
 

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -136,7 +136,7 @@ def test_smbios_model_fallback():
     cfg.smbios_model = ""  # empty model triggers fallback
     steps = build_plan(cfg)
     smbios_step = next(step for step in steps if step.title == "Set SMBIOS identity")
-    assert f"product={base64.b64encode(b'iMacPro1,1').decode()}" in smbios_step.command
+    assert f"product={base64.b64encode(b'MacPro7,1').decode()}" in smbios_step.command
 
 
 def test_build_plan_includes_build_oc_step() -> None:

--- a/tests/test_smbios.py
+++ b/tests/test_smbios.py
@@ -36,14 +36,14 @@ def test_rom_format() -> None:
 
 
 def test_model_for_known_macos() -> None:
-    assert model_for_macos("ventura") == "iMacPro1,1"
-    assert model_for_macos("sonoma") == "iMacPro1,1"
-    assert model_for_macos("sequoia") == "iMacPro1,1"
+    assert model_for_macos("ventura") == "MacPro7,1"
+    assert model_for_macos("sonoma") == "MacPro7,1"
+    assert model_for_macos("sequoia") == "MacPro7,1"
     assert model_for_macos("tahoe") == "MacPro7,1"
 
 
 def test_model_for_unknown_macos() -> None:
-    assert model_for_macos("unknown") == "iMacPro1,1"
+    assert model_for_macos("unknown") == "MacPro7,1"
 
 
 def test_generate_smbios_complete() -> None:
@@ -51,7 +51,7 @@ def test_generate_smbios_complete() -> None:
     assert len(identity.serial) == 12
     assert len(identity.mlb) == 17
     assert len(identity.rom) == 12
-    assert identity.model == "iMacPro1,1"
+    assert identity.model == "MacPro7,1"
     uuid_mod.UUID(identity.uuid)
 
 


### PR DESCRIPTION
## Summary
- Changed default SMBIOS model from `iMacPro1,1` to `MacPro7,1` for all macOS versions
- `iMacPro1,1` is not supported by OpenCore Legacy Patcher for Sonoma/Sequoia, causing the "Build and Install OpenCore" option to be greyed out in Recovery

## Changes
- `src/osx_proxmox_next/smbios.py` - Updated SMBIOS_MODELS and DEFAULT_SMBIOS_MODEL
- `scripts/bash/osx-proxmox-next.sh` - Updated SMBIOS_MODELS array and fallback default
- `tests/test_smbios.py` - Updated test assertions
- `tests/test_planner.py` - Updated test assertion  
- `tests/test_app_wizard.py` - Updated test assertion
- `README.md` - Updated CLI example

## Testing
- [x] Unit tests pass (42/42)

## Related
- Reddit issue: r/Proxmox/comments/1r0rg8z