### PR TITLE
feat: add option to preserve existing SMBIOS UUID

### DIFF
--- a/scripts/bash/osx-proxmox-next.sh
+++ b/scripts/bash/osx-proxmox-next.sh
@@ -306,10 +306,15 @@ function detect_memory_mb() {
 # ── Generate SMBIOS identity ──
 function generate_smbios() {
   local macos_ver="$1"
+  local existing_uuid="$2"
   SMBIOS_SERIAL=$(cat /dev/urandom | tr -dc 'A-Z0-9' | head -c 12)
   SMBIOS_MLB=$(cat /dev/urandom | tr -dc 'A-Z0-9' | head -c 17)
   SMBIOS_ROM=$(openssl rand -hex 6 | tr '[:lower:]' '[:upper:]')
-  SMBIOS_UUID=$(cat /proc/sys/kernel/random/uuid | tr '[:lower:]' '[:upper:]')
+  if [ -n "$existing_uuid" ]; then
+    SMBIOS_UUID="$existing_uuid"
+  else
+    SMBIOS_UUID=$(cat /proc/sys/kernel/random/uuid | tr '[:lower:]' '[:upper:]')
+  fi
   SMBIOS_MODEL="${SMBIOS_MODELS[$macos_ver]:-MacPro7,1}"
 }
 


### PR DESCRIPTION
## Summary
Adds optional field to preserve existing SMBIOS UUID when creating VMs, addressing concern that `qm set --smbios1` replaces the entire blob.

## Changes
- Add "Existing UUID (optional)" input field in TUI step 4
- Modify bash script `generate_smbios()` to accept optional UUID parameter
- CLI already supported `--smbios-uuid` flag

## Test plan
- [ ] Test TUI with existing UUID input
- [ ] Test TUI without UUID (generates new)
- [ ] Verify bash script with/without UUID param