### PR TITLE
feat(cli): add --version flag and --json plan output

### DIFF
--- a/src/osx_proxmox_next/cli.py
+++ b/src/osx_proxmox_next/cli.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from pathlib import Path
 
+from . import __version__
 from .assets import required_assets, suggested_fetch_commands
 from .defaults import DEFAULT_ISO_DIR, detect_cpu_info, detect_iso_storage
 from .diagnostics import export_log_bundle, recovery_guide
@@ -75,6 +77,7 @@ def _auto_download_missing(config: VmConfig, dest_dir: Path) -> None:
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="osx-next-cli")
+    parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
     sub = parser.add_subparsers(dest="cmd", required=True)
 
     sub.add_parser("preflight")
@@ -119,6 +122,8 @@ def build_parser() -> argparse.ArgumentParser:
 
     plan = sub.add_parser("plan", parents=[common])
     plan.add_argument("--script-out", type=str, default="")
+    plan.add_argument("--json", action="store_true", default=False,
+                      help="Output plan as JSON instead of human-readable text")
 
     apply_cmd = sub.add_parser("apply", parents=[common])
     apply_cmd.add_argument("--execute", action="store_true")
@@ -181,21 +186,30 @@ def run_cli(argv: list[str] | None = None) -> int:
         return 3
 
     cpu = detect_cpu_info()
-    if config.cpu_model:
-        cpu_mode = f"override: {config.cpu_model}"
-    elif cpu.needs_emulated_cpu:
-        cpu_mode = "Cascadelake-Server emulation"
-    else:
-        cpu_mode = "native host passthrough"
-    cpu_label = cpu.model_name or cpu.vendor
-    print(f"CPU: {cpu_label} ({cpu_mode})")
+    json_mode = args.cmd == "plan" and getattr(args, "json", False)
+    if not json_mode:
+        if config.cpu_model:
+            cpu_mode = f"override: {config.cpu_model}"
+        elif cpu.needs_emulated_cpu:
+            cpu_mode = "Cascadelake-Server emulation"
+        else:
+            cpu_mode = "native host passthrough"
+        cpu_label = cpu.model_name or cpu.vendor
+        print(f"CPU: {cpu_label} ({cpu_mode})")
 
     steps = build_plan(config)
 
     if args.cmd == "plan":
-        for idx, step in enumerate(steps, start=1):
-            print(f"{idx:02d}. {step.title}")
-            print(f"    {step.command}")
+        if getattr(args, "json", False):
+            plan_data = [
+                {"step": idx, "title": step.title, "command": step.command, "risk": step.risk}
+                for idx, step in enumerate(steps, start=1)
+            ]
+            print(json.dumps(plan_data, indent=2))
+        else:
+            for idx, step in enumerate(steps, start=1):
+                print(f"{idx:02d}. {step.title}")
+                print(f"    {step.command}")
         if args.script_out:
             out = Path(args.script_out)
             out.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,6 +16,65 @@ def test_cli_parser_has_expected_commands() -> None:
     assert "download" in cmds
 
 
+def test_cli_version(capsys):
+    """--version flag prints version and exits."""
+    import pytest
+    from osx_proxmox_next import __version__
+    with pytest.raises(SystemExit) as exc_info:
+        run_cli(["--version"])
+    assert exc_info.value.code == 0
+    captured = capsys.readouterr()
+    assert __version__ in captured.out
+
+
+def test_cli_plan_json(monkeypatch, capsys):
+    """--json flag outputs plan as JSON array."""
+    import json as json_mod
+    from osx_proxmox_next.assets import AssetCheck
+    monkeypatch.setattr(
+        cli_module, "required_assets",
+        lambda cfg: [AssetCheck("OC", Path("/tmp/oc.iso"), True, ""), AssetCheck("Rec", Path("/tmp/rec.iso"), True, "")],
+    )
+    rc = run_cli(_plan_args() + ["--json"])
+    assert rc == 0
+    captured = capsys.readouterr()
+    data = json_mod.loads(captured.out)
+    assert isinstance(data, list)
+    assert len(data) > 0
+    assert "title" in data[0]
+    assert "command" in data[0]
+    assert "risk" in data[0]
+    assert "step" in data[0]
+    # JSON mode should NOT print CPU info
+    assert "CPU:" not in captured.out
+
+
+def test_cli_plan_prints_cpu_info(monkeypatch, capsys):
+    """Non-JSON plan prints CPU info line."""
+    from osx_proxmox_next.assets import AssetCheck
+    monkeypatch.setattr(
+        cli_module, "required_assets",
+        lambda cfg: [AssetCheck("OC", Path("/tmp/oc.iso"), True, ""), AssetCheck("Rec", Path("/tmp/rec.iso"), True, "")],
+    )
+    rc = run_cli(_plan_args())
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "CPU:" in captured.out
+
+
+def test_cli_plan_cpu_override_display(monkeypatch, capsys):
+    """CPU model override is shown in plan output."""
+    from osx_proxmox_next.assets import AssetCheck
+    monkeypatch.setattr(
+        cli_module, "required_assets",
+        lambda cfg: [AssetCheck("OC", Path("/tmp/oc.iso"), True, ""), AssetCheck("Rec", Path("/tmp/rec.iso"), True, "")],
+    )
+    rc = run_cli(_plan_args() + ["--cpu-model", "Skylake-Server-IBRS"])
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "override" in captured.out
+
+
 def test_cli_preflight(monkeypatch):
     from osx_proxmox_next.preflight import PreflightCheck
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- Add `--version` flag to CLI
- Add `--json` output mode for `plan` subcommand

## Changes
- `--version` prints `osx-next-cli X.Y.Z` and exits
- `--json` on `plan` outputs machine-readable JSON array with step/title/command/risk
- JSON mode suppresses CPU info line for clean piping
- 4 new tests covering version, JSON output, CPU info display, and CPU override display

## Test plan
- [x] `osx-next-cli --version` prints version
- [x] `osx-next-cli plan --json ...` outputs valid JSON
- [x] Non-JSON plan still shows CPU info
- [x] 420 tests pass, 99% coverage