### PR TITLE
feat(cli): add status subcommand

### DIFF
--- a/src/osx_proxmox_next/cli.py
+++ b/src/osx_proxmox_next/cli.py
@@ -128,6 +128,10 @@ def build_parser() -> argparse.ArgumentParser:
     apply_cmd = sub.add_parser("apply", parents=[common])
     apply_cmd.add_argument("--execute", action="store_true")
 
+    # Status subcommand
+    status = sub.add_parser("status", help="Show info about an existing macOS VM")
+    status.add_argument("--vmid", type=int, required=True, help="VM ID to query")
+
     # Uninstall subcommand
     uninstall = sub.add_parser("uninstall", help="Destroy an existing macOS VM")
     uninstall.add_argument("--vmid", type=int, required=True, help="VM ID to destroy")
@@ -157,6 +161,9 @@ def run_cli(argv: list[str] | None = None) -> int:
 
     if args.cmd == "download":
         return _run_download(args)
+
+    if args.cmd == "status":
+        return _run_status(args)
 
     if args.cmd == "uninstall":
         return _run_uninstall(args)
@@ -229,6 +236,27 @@ def run_cli(argv: list[str] | None = None) -> int:
     for hint in rollback_hints(snapshot):
         print(f"ROLLBACK: {hint}")
     return 4
+
+
+def _run_status(args: argparse.Namespace) -> int:
+    vmid = args.vmid
+    if vmid < 100 or vmid > 999999:
+        print("ERROR: VMID must be between 100 and 999999.")
+        return 2
+
+    info = fetch_vm_info(vmid)
+    if info is None:
+        print(f"ERROR: VM {vmid} not found.")
+        return 2
+
+    print(f"VM {vmid}: {info.name}")
+    print(f"Status: {info.status}")
+    if info.config_raw:
+        for line in info.config_raw.splitlines():
+            key = line.split(":")[0].strip()
+            if key in ("cores", "memory", "balloon", "net0", "smbios1", "cpu", "machine"):
+                print(f"  {line.strip()}")
+    return 0
 
 
 def _run_uninstall(args: argparse.Namespace) -> int:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -553,6 +553,61 @@ def test_cli_auto_download_on_missing(monkeypatch, tmp_path):
     assert rc == 0
 
 
+# ── Status Tests ────────────────────────────────────────────────────
+
+
+def test_cli_parser_has_status_command() -> None:
+    from osx_proxmox_next.cli import build_parser
+    parser = build_parser()
+    cmds = parser._subparsers._group_actions[0].choices  # type: ignore[attr-defined]
+    assert "status" in cmds
+
+
+def test_cli_status_invalid_vmid():
+    rc = run_cli(["status", "--vmid", "5"])
+    assert rc == 2
+
+
+def test_cli_status_vm_not_found(monkeypatch):
+    monkeypatch.setattr(cli_module, "fetch_vm_info", lambda vmid: None)
+    rc = run_cli(["status", "--vmid", "106"])
+    assert rc == 2
+
+
+def test_cli_status_success(monkeypatch, capsys):
+    from osx_proxmox_next.planner import VmInfo
+    monkeypatch.setattr(
+        cli_module, "fetch_vm_info",
+        lambda vmid: VmInfo(
+            vmid=vmid, name="macos-sonoma", status="running",
+            config_raw="cores: 8\nmemory: 16384\nballoon: 0\nnet0: vmxnet3=AA:BB:CC:DD:EE:FF\ncpu: host\nmachine: q35\nide0: local:iso/opencore.iso\n",
+        ),
+    )
+    rc = run_cli(["status", "--vmid", "106"])
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "macos-sonoma" in captured.out
+    assert "running" in captured.out
+    assert "cores: 8" in captured.out
+    assert "memory: 16384" in captured.out
+    assert "balloon: 0" in captured.out
+    # ide0 should NOT be printed (not in the filter list)
+    assert "ide0" not in captured.out
+
+
+def test_cli_status_no_config(monkeypatch, capsys):
+    from osx_proxmox_next.planner import VmInfo
+    monkeypatch.setattr(
+        cli_module, "fetch_vm_info",
+        lambda vmid: VmInfo(vmid=vmid, name="test-vm", status="stopped", config_raw=""),
+    )
+    rc = run_cli(["status", "--vmid", "200"])
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "test-vm" in captured.out
+    assert "stopped" in captured.out
+
+
 # ── Uninstall Tests ─────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
- Adds `osx-next-cli status --vmid <id>` subcommand
- Shows VM name, running state, and key config fields (cores, memory, cpu, network, smbios)
- Validates VMID range, returns error if VM not found

## Changes
- `cli.py`: new `status` parser + `_run_status()` handler
- `test_cli.py`: 5 new tests (parser, invalid vmid, not found, success, no config)

## Test plan
- [x] `uv run pytest` — 424 passed, 99.55% coverage
- [x] Invalid VMID returns exit code 2
- [x] Missing VM returns exit code 2
- [x] Valid VM prints name, status, filtered config lines