### PR TITLE
refactor: centralize ISO directory constant

### DIFF
--- a/src/osx_proxmox_next/assets.py
+++ b/src/osx_proxmox_next/assets.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from fnmatch import fnmatch
 from pathlib import Path
 
+from .defaults import DEFAULT_ISO_DIR
 from .domain import VmConfig
 
 
@@ -45,7 +46,7 @@ def required_assets(config: VmConfig) -> list[AssetCheck]:
 
 
 def suggested_fetch_commands(config: VmConfig) -> list[str]:
-    iso_root = config.iso_dir or "/var/lib/vz/template/iso"
+    iso_root = config.iso_dir or DEFAULT_ISO_DIR
     return [
         f"# Auto-download available — run: osx-next-cli download --macos {config.macos}",
         f"# Or manually place OpenCore image at {iso_root}/opencore-{config.macos}.iso",
@@ -64,7 +65,7 @@ def resolve_opencore_path(macos: str, extra_dirs: list[Path] | None = None) -> P
     )
     if match:
         return match
-    return Path("/var/lib/vz/template/iso") / "opencore-osx-proxmox-vm.iso"
+    return Path(DEFAULT_ISO_DIR) / "opencore-osx-proxmox-vm.iso"
 
 
 def resolve_recovery_or_installer_path(
@@ -82,14 +83,14 @@ def resolve_recovery_or_installer_path(
     )
     if match:
         return match
-    return Path("/var/lib/vz/template/iso") / f"{config.macos}-recovery.iso"
+    return Path(DEFAULT_ISO_DIR) / f"{config.macos}-recovery.iso"
 
 
 def _find_iso(
     patterns: list[str], extra_dirs: list[Path] | None = None,
 ) -> Path | None:
     roots = [
-        Path("/var/lib/vz/template/iso"),
+        Path(DEFAULT_ISO_DIR),
     ]
     if extra_dirs:
         for d in extra_dirs:

--- a/src/osx_proxmox_next/cli.py
+++ b/src/osx_proxmox_next/cli.py
@@ -89,7 +89,7 @@ def build_parser() -> argparse.ArgumentParser:
     # Download subcommand
     dl = sub.add_parser("download", help="Download OpenCore ISOs and macOS recovery images")
     dl.add_argument("--macos", type=str, required=True, help="macOS target (ventura, sonoma, sequoia, tahoe)")
-    dl.add_argument("--dest", type=str, default="/var/lib/vz/template/iso", help="Destination directory")
+    dl.add_argument("--dest", type=str, default=DEFAULT_ISO_DIR, help="Destination directory")
     dl.add_argument("--opencore-only", action="store_true", help="Only download OpenCore ISO")
     dl.add_argument("--recovery-only", action="store_true", help="Only download recovery image")
 


### PR DESCRIPTION
## Summary
- Replace 4 hardcoded `/var/lib/vz/template/iso` strings with `DEFAULT_ISO_DIR` from `defaults.py`
- Single source of truth for the default ISO path

## Changes
| File | Change |
|------|--------|
| `assets.py` | Import and use `DEFAULT_ISO_DIR` (3 occurrences) |
| `cli.py` | Use `DEFAULT_ISO_DIR` for `--dest` default |

## Test plan
- [x] 436 tests pass
- [x] Coverage at 99.55%