### PR TITLE
feat(preflight): auto-install missing build deps and audit fixes

### DIFF
--- a/src/osx_proxmox_next/app.py
+++ b/src/osx_proxmox_next/app.py
@@ -21,11 +21,19 @@ from .downloader import DownloadError, DownloadProgress, download_opencore, down
 from .executor import StepResult, apply_plan
 from .infrastructure import ProxmoxAdapter
 from .planner import PlanStep, build_plan, build_destroy_plan, fetch_vm_info
-from .preflight import PreflightCheck, run_preflight
+from .preflight import PreflightCheck, run_preflight, has_missing_build_deps, install_missing_packages
 from .rollback import RollbackSnapshot, create_snapshot, rollback_hints
 from .smbios import generate_smbios, SmbiosIdentity
 
-_pve = ProxmoxAdapter()
+_pve: ProxmoxAdapter | None = None
+
+
+def _get_pve() -> ProxmoxAdapter:
+    """Lazy singleton to avoid import-time side effects."""
+    global _pve  # noqa: PLW0603
+    if _pve is None:
+        _pve = ProxmoxAdapter()
+    return _pve
 
 
 @dataclass
@@ -867,9 +875,7 @@ class NextApp(App):
         if result is None:
             self._append_log("#dry_log", f"Running {idx}/{total}: {title}")
         else:
-            ok = getattr(result, "ok", False)
-            rc = getattr(result, "returncode", 0)
-            self._append_log("#dry_log", f"{'OK' if ok else 'FAIL'} {idx}/{total}: {title} (rc={rc})")
+            self._append_log("#dry_log", f"{'OK' if result.ok else 'FAIL'} {idx}/{total}: {title} (rc={result.returncode})")
 
     def _finish_dry_apply(self, ok: bool, log_path: Path) -> None:
         self.state.apply_running = False
@@ -930,9 +936,7 @@ class NextApp(App):
         if result is None:
             self._append_log("#live_log", f"Running {idx}/{total}: {title}")
         else:
-            ok = getattr(result, "ok", False)
-            rc = getattr(result, "returncode", 0)
-            self._append_log("#live_log", f"{'OK' if ok else 'FAIL'} {idx}/{total}: {title} (rc={rc})")
+            self._append_log("#live_log", f"{'OK' if result.ok else 'FAIL'} {idx}/{total}: {title} (rc={result.returncode})")
 
     def _finish_live_install(
         self, ok: bool, log_path: Path, snapshot: RollbackSnapshot | None
@@ -996,7 +1000,7 @@ class NextApp(App):
 
     def _vm_list_worker(self) -> None:
         try:
-            res = _pve.qm("list")
+            res = _get_pve().qm("list")
             if not res.ok:
                 self.call_from_thread(self._finish_vm_list, [])
                 return
@@ -1008,7 +1012,7 @@ class NextApp(App):
                 if not parts:
                     continue
                 vmid = parts[0]
-                cfg_res = _pve.qm("config", vmid)
+                cfg_res = _get_pve().qm("config", vmid)
                 if cfg_res.ok and "isa-applesmc" in cfg_res.output:
                     macos_lines.append(line)
             header = all_lines[0] if all_lines else ""
@@ -1085,8 +1089,7 @@ class NextApp(App):
         if result is None:
             self.state.uninstall_log.append(f"Running {idx}/{total}: {title}")
         else:
-            ok = getattr(result, "ok", False)
-            self.state.uninstall_log.append(f"{'OK' if ok else 'FAIL'} {idx}/{total}: {title}")
+            self.state.uninstall_log.append(f"{'OK' if result.ok else 'FAIL'} {idx}/{total}: {title}")
         visible = self.state.uninstall_log[-10:]
         self.query_one("#manage_log", Static).update("\n".join(visible))
 
@@ -1111,7 +1114,16 @@ class NextApp(App):
 
     def _preflight_worker(self) -> None:
         checks = run_preflight()
+        if has_missing_build_deps(checks):
+            def _on_output(msg: str) -> None:
+                self.call_from_thread(self._update_preflight_status, msg)
+            ok, pkgs = install_missing_packages(on_output=_on_output)
+            if ok and pkgs:
+                checks = run_preflight()
         self.call_from_thread(self._finish_preflight, checks)
+
+    def _update_preflight_status(self, msg: str) -> None:
+        self.query_one("#preflight_checks", Static).update(f"  ⏳ {msg}")
 
     def _finish_preflight(self, checks: list[PreflightCheck]) -> None:
         self.state.preflight_done = True
@@ -1123,7 +1135,7 @@ class NextApp(App):
     # ── Detection Helpers ───────────────────────────────────────────
 
     def _detect_storage_targets(self) -> list[str]:
-        res = _pve.pvesm("status", "-content", "images")
+        res = _get_pve().pvesm("status", "-content", "images")
         if not res.ok:
             log.debug("Failed to detect storage targets: %s", res.output)
             return [DEFAULT_STORAGE, "local"]
@@ -1139,7 +1151,7 @@ class NextApp(App):
         return targets[:5]
 
     def _detect_next_vmid(self) -> int:
-        res = _pve.pvesh("get", "/cluster/nextid")
+        res = _get_pve().pvesh("get", "/cluster/nextid")
         if res.ok:
             output = res.output.strip()
             if output.isdigit():
@@ -1155,7 +1167,7 @@ class NextApp(App):
         else:
             log.debug("Failed to get next VMID via pvesh: %s", res.output)
 
-        res = _pve.qm("list")
+        res = _get_pve().qm("list")
         if res.ok:
             vmids: list[int] = []
             for line in res.output.splitlines()[1:]:

--- a/src/osx_proxmox_next/cli.py
+++ b/src/osx_proxmox_next/cli.py
@@ -13,7 +13,7 @@ from .domain import MIN_VMID, MAX_VMID, VmConfig, validate_config
 from .downloader import DownloadError, DownloadProgress, download_opencore, download_recovery
 from .executor import apply_plan
 from .planner import build_plan, build_destroy_plan, fetch_vm_info, render_script
-from .preflight import run_preflight
+from .preflight import run_preflight, has_missing_build_deps, install_missing_packages
 from .rollback import create_snapshot, rollback_hints
 
 
@@ -146,7 +146,12 @@ def run_cli(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     if args.cmd == "preflight":
-        for check in run_preflight():
+        checks = run_preflight()
+        if has_missing_build_deps(checks):
+            ok, pkgs = install_missing_packages(on_output=lambda msg: print(f"  -> {msg}"))
+            if ok and pkgs:
+                checks = run_preflight()
+        for check in checks:
             print(f"{'OK' if check.ok else 'FAIL'} {check.name}: {check.details}")
         return 0
 

--- a/src/osx_proxmox_next/downloader.py
+++ b/src/osx_proxmox_next/downloader.py
@@ -1,17 +1,18 @@
 from __future__ import annotations
 
 import secrets
-import subprocess
 import time
 import urllib.error
 import urllib.request
 from dataclasses import dataclass
 from json import loads as json_loads
 from pathlib import Path
-from typing import Callable, Optional
+from collections.abc import Callable
+from typing import Optional
 from urllib.parse import urlparse
 
 from . import __version__
+from .infrastructure import ProxmoxAdapter
 
 
 @dataclass
@@ -120,20 +121,17 @@ def download_recovery(
 
 
 def _build_recovery_image(dmg_path: Path, _chunklist_path: Path, dest: Path) -> None:
-    try:
-        subprocess.run(
-            ["dmg2img", str(dmg_path), str(dest)],
-            check=True, capture_output=True,
-        )
-    except subprocess.CalledProcessError as exc:
+    adapter = ProxmoxAdapter()
+    result = adapter.run(["dmg2img", str(dmg_path), str(dest)])
+    if not result.ok:
         if dest.exists():
             dest.unlink()
-        raise DownloadError(f"Failed to convert recovery DMG: {exc.stderr}") from exc
-    except FileNotFoundError:
-        raise DownloadError(
-            "dmg2img is required but not installed. "
-            "Install it with: apt install dmg2img"
-        )
+        if result.returncode == 127:
+            raise DownloadError(
+                "dmg2img is required but not installed. "
+                "Install it with: apt install dmg2img"
+            )
+        raise DownloadError(f"Failed to convert recovery DMG: {result.output}")
 
 
 def _fetch_github_releases(version: str) -> list[dict]:
@@ -251,7 +249,7 @@ def _retry_download(
     dest.parent.mkdir(parents=True, exist_ok=True)
     part_path = dest.parent / (dest.name + ".part")
 
-    last_error: Optional[Exception] = None
+    last_error: Exception | None = None
     for attempt in range(_MAX_RETRIES):
         try:
             _do_download(url, part_path, on_progress, phase, extra_headers=extra_headers)

--- a/src/osx_proxmox_next/executor.py
+++ b/src/osx_proxmox_next/executor.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Callable, Optional
+from collections.abc import Callable
+from typing import Optional
 
 from .infrastructure import ProxmoxAdapter
 from .planner import PlanStep

--- a/src/osx_proxmox_next/planner.py
+++ b/src/osx_proxmox_next/planner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import copy
 import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -88,6 +89,10 @@ def build_plan(config: VmConfig) -> list[PlanStep]:
     issues = validate_config(config)
     if issues:
         raise ValueError(f"Invalid VM config: {'; '.join(issues)}")
+
+    # Work on a copy so callers don't see SMBIOS side effects.
+    config = copy.copy(config)
+
     meta = SUPPORTED_MACOS[config.macos]
     vmid = str(config.vmid)
 

--- a/src/osx_proxmox_next/preflight.py
+++ b/src/osx_proxmox_next/preflight.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
+import logging
+from collections.abc import Callable
 from dataclasses import dataclass
 import os
 from pathlib import Path
 import shutil
 
 from .defaults import detect_cpu_vendor
+from .infrastructure import CommandResult, ProxmoxAdapter
+
+log = logging.getLogger(__name__)
 
 
 @dataclass
@@ -37,12 +42,12 @@ def _is_root() -> bool:
 _PROXMOX_BINARIES = ("qm", "pvesm", "pvesh", "qemu-img")
 
 _BUILD_BINARIES: dict[str, str] = {
-    "dmg2img": "apt install dmg2img",
-    "sgdisk": "apt install gdisk",
-    "partprobe": "apt install parted",
-    "losetup": "apt install mount",
-    "mkfs.fat": "apt install dosfstools",
-    "blkid": "apt install util-linux",
+    "dmg2img": "dmg2img",
+    "sgdisk": "gdisk",
+    "partprobe": "parted",
+    "losetup": "mount",
+    "mkfs.fat": "dosfstools",
+    "blkid": "util-linux",
 }
 
 
@@ -114,13 +119,13 @@ def run_preflight() -> list[PreflightCheck]:
             )
         )
 
-    for cmd, install_hint in _BUILD_BINARIES.items():
+    for cmd, pkg in _BUILD_BINARIES.items():
         binary = _find_binary(cmd)
         checks.append(
             PreflightCheck(
                 name=f"{cmd} available",
                 ok=bool(binary),
-                details=binary or f"Not found. Install with: {install_hint}",
+                details=binary or f"Not found. Install with: apt install {pkg}",
             )
         )
 
@@ -151,3 +156,53 @@ def run_preflight() -> list[PreflightCheck]:
         )
     )
     return checks
+
+
+def has_missing_build_deps(checks: list[PreflightCheck]) -> bool:
+    """Return True if any build dependency checks failed."""
+    return any(
+        not c.ok and c.name.endswith("available") and c.name.split()[0] in _BUILD_BINARIES
+        for c in checks
+    )
+
+
+def find_missing_packages() -> list[str]:
+    """Return apt package names for missing build binaries."""
+    packages: list[str] = []
+    for cmd, pkg in _BUILD_BINARIES.items():
+        if not _find_binary(cmd):
+            if pkg not in packages:
+                packages.append(pkg)
+    return packages
+
+
+def install_missing_packages(
+    on_output: Callable[[str], None] | None = None,
+    adapter: ProxmoxAdapter | None = None,
+) -> tuple[bool, list[str]]:
+    """Auto-install missing build dependencies via apt-get.
+
+    Returns (success, list_of_installed_packages).
+    Calls *on_output* with status messages if provided.
+    """
+    if not _is_root():
+        return False, []
+
+    packages = find_missing_packages()
+    if not packages:
+        return True, []
+
+    def _emit(msg: str) -> None:
+        log.info(msg)
+        if on_output:
+            on_output(msg)
+
+    _emit(f"Installing: {', '.join(packages)}")
+
+    runtime = adapter or ProxmoxAdapter()
+    result = runtime.run(["apt-get", "install", "-y", *packages])
+    if result.ok:
+        _emit("Installation complete")
+        return True, packages
+    _emit(f"apt-get failed (exit {result.returncode}): {result.output}")
+    return False, []

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -296,18 +296,25 @@ def test_cli_main_block(monkeypatch):
         assert e.code == 0
 
 
-def test_cli_progress_with_total():
+def test_cli_progress_with_total(capsys):
     from osx_proxmox_next.cli import _cli_progress
     from osx_proxmox_next.downloader import DownloadProgress
     p = DownloadProgress(downloaded=1048576, total=2097152, phase="opencore")
     _cli_progress(p)
+    out = capsys.readouterr().out
+    assert "opencore" in out
+    assert "50%" in out
+    assert "1.0" in out
 
 
-def test_cli_progress_without_total():
+def test_cli_progress_without_total(capsys):
     from osx_proxmox_next.cli import _cli_progress
     from osx_proxmox_next.downloader import DownloadProgress
     p = DownloadProgress(downloaded=1048576, total=0, phase="recovery")
     _cli_progress(p)
+    out = capsys.readouterr().out
+    assert "recovery" in out
+    assert "1.0" in out
 
 
 def test_auto_download_missing_opencore(monkeypatch, tmp_path):

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -612,10 +612,19 @@ class TestDownloadFileWithToken:
         assert progress_calls[0].phase == "recovery"
 
 
+class _FakeAdapter:
+    """Test helper that wraps a handler function as a ProxmoxAdapter."""
+    def __init__(self, handler):
+        self._handler = handler
+
+    def run(self, argv):
+        return self._handler(argv)
+
+
 class TestBuildRecoveryImage:
     def test_success(self, tmp_path, monkeypatch):
-        import subprocess as real_subprocess
         from osx_proxmox_next.downloader import _build_recovery_image
+        from osx_proxmox_next.infrastructure import CommandResult
 
         dmg = tmp_path / "BaseSystem.dmg"
         chunklist = tmp_path / "BaseSystem.chunklist"
@@ -623,21 +632,21 @@ class TestBuildRecoveryImage:
         chunklist.write_bytes(b"y" * 64)
         dest = tmp_path / "recovery.img"
 
-        def fake_run(argv, **kw):
+        def handler(argv):
             assert argv[0] == "dmg2img"
             assert argv[1] == str(dmg)
             assert argv[2] == str(dest)
             dest.write_bytes(b"\x00" * 2048)
-            return real_subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+            return CommandResult(ok=True, returncode=0, output="")
 
-        monkeypatch.setattr(dl_module.subprocess, "run", fake_run)
+        monkeypatch.setattr(dl_module, "ProxmoxAdapter", lambda: _FakeAdapter(handler))
 
         _build_recovery_image(dmg, chunklist, dest)
         assert dest.exists()
 
     def test_failure_cleans_up(self, tmp_path, monkeypatch):
-        import subprocess as real_subprocess
         from osx_proxmox_next.downloader import _build_recovery_image
+        from osx_proxmox_next.infrastructure import CommandResult
 
         dmg = tmp_path / "BaseSystem.dmg"
         chunklist = tmp_path / "BaseSystem.chunklist"
@@ -646,18 +655,18 @@ class TestBuildRecoveryImage:
         dest = tmp_path / "recovery.img"
         dest.write_bytes(b"partial")
 
-        def fake_run(argv, **kw):
-            raise real_subprocess.CalledProcessError(1, argv, stderr=b"dmg2img failed")
+        def handler(argv):
+            return CommandResult(ok=False, returncode=1, output="dmg2img failed")
 
-        monkeypatch.setattr(dl_module.subprocess, "run", fake_run)
+        monkeypatch.setattr(dl_module, "ProxmoxAdapter", lambda: _FakeAdapter(handler))
 
         with pytest.raises(DownloadError, match="Failed to convert recovery DMG"):
             _build_recovery_image(dmg, chunklist, dest)
         assert not dest.exists()
 
     def test_failure_no_dest_to_clean(self, tmp_path, monkeypatch):
-        import subprocess as real_subprocess
         from osx_proxmox_next.downloader import _build_recovery_image
+        from osx_proxmox_next.infrastructure import CommandResult
 
         dmg = tmp_path / "BaseSystem.dmg"
         chunklist = tmp_path / "BaseSystem.chunklist"
@@ -665,10 +674,10 @@ class TestBuildRecoveryImage:
         chunklist.write_bytes(b"y" * 64)
         dest = tmp_path / "recovery.img"
 
-        def fake_run(argv, **kw):
-            raise real_subprocess.CalledProcessError(1, argv, stderr=b"dmg2img failed")
+        def handler(argv):
+            return CommandResult(ok=False, returncode=1, output="dmg2img failed")
 
-        monkeypatch.setattr(dl_module.subprocess, "run", fake_run)
+        monkeypatch.setattr(dl_module, "ProxmoxAdapter", lambda: _FakeAdapter(handler))
 
         with pytest.raises(DownloadError, match="Failed to convert recovery DMG"):
             _build_recovery_image(dmg, chunklist, dest)
@@ -676,6 +685,7 @@ class TestBuildRecoveryImage:
 
     def test_failure_dmg2img_not_found(self, tmp_path, monkeypatch):
         from osx_proxmox_next.downloader import _build_recovery_image
+        from osx_proxmox_next.infrastructure import CommandResult
 
         dmg = tmp_path / "BaseSystem.dmg"
         chunklist = tmp_path / "BaseSystem.chunklist"
@@ -683,10 +693,10 @@ class TestBuildRecoveryImage:
         chunklist.write_bytes(b"y" * 64)
         dest = tmp_path / "recovery.img"
 
-        def fake_run(argv, **kw):
-            raise FileNotFoundError("dmg2img")
+        def handler(argv):
+            return CommandResult(ok=False, returncode=127, output="Command not found: dmg2img")
 
-        monkeypatch.setattr(dl_module.subprocess, "run", fake_run)
+        monkeypatch.setattr(dl_module, "ProxmoxAdapter", lambda: _FakeAdapter(handler))
 
         with pytest.raises(DownloadError, match="dmg2img is required but not installed"):
             _build_recovery_image(dmg, chunklist, dest)

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1,7 +1,13 @@
 from pathlib import Path
 
 from osx_proxmox_next import preflight
-from osx_proxmox_next.preflight import run_preflight
+from osx_proxmox_next.preflight import (
+    PreflightCheck,
+    run_preflight,
+    has_missing_build_deps,
+    find_missing_packages,
+    install_missing_packages,
+)
 
 
 def test_preflight_has_expected_checks() -> None:
@@ -137,3 +143,131 @@ def test_build_binary_missing_shows_install_hint(monkeypatch):
     partprobe = [c for c in checks if c.name == "partprobe available"][0]
     assert partprobe.ok is False
     assert "apt install parted" in partprobe.details
+
+
+# ── has_missing_build_deps tests ─────────────────────────────────
+
+
+def test_has_missing_build_deps_none_missing():
+    checks = [
+        PreflightCheck("dmg2img available", True, "/usr/bin/dmg2img"),
+        PreflightCheck("sgdisk available", True, "/usr/sbin/sgdisk"),
+        PreflightCheck("KVM ignore_msrs", False, "missing"),
+    ]
+    assert has_missing_build_deps(checks) is False
+
+
+def test_has_missing_build_deps_some_missing():
+    checks = [
+        PreflightCheck("dmg2img available", False, "Not found"),
+        PreflightCheck("sgdisk available", True, "/usr/sbin/sgdisk"),
+    ]
+    assert has_missing_build_deps(checks) is True
+
+
+def test_has_missing_build_deps_ignores_non_build_checks():
+    checks = [
+        PreflightCheck("qm available", False, "not found"),
+        PreflightCheck("KVM ignore_msrs", False, "missing"),
+    ]
+    assert has_missing_build_deps(checks) is False
+
+
+# ── Auto-install tests ──────────────────────────────────────────
+
+
+def test_find_missing_packages_all_present(monkeypatch):
+    monkeypatch.setattr(preflight.shutil, "which", lambda cmd: f"/usr/bin/{cmd}")
+    assert find_missing_packages() == []
+
+
+def test_find_missing_packages_some_missing(monkeypatch):
+    present = {"sgdisk", "losetup", "mkfs.fat", "blkid"}
+    monkeypatch.setattr(
+        preflight.shutil, "which",
+        lambda cmd: f"/usr/bin/{cmd}" if cmd in present else None,
+    )
+    monkeypatch.setattr(Path, "exists", lambda self: False)
+    missing = find_missing_packages()
+    assert "dmg2img" in missing
+    assert "parted" in missing
+    assert "gdisk" not in missing
+
+
+def test_find_missing_packages_no_duplicates(monkeypatch):
+    monkeypatch.setattr(preflight.shutil, "which", lambda _cmd: None)
+    monkeypatch.setattr(Path, "exists", lambda self: False)
+    missing = find_missing_packages()
+    assert len(missing) == len(set(missing))
+
+
+def test_install_missing_packages_not_root(monkeypatch):
+    monkeypatch.setattr(preflight.os, "geteuid", lambda: 1000)
+    ok, pkgs = install_missing_packages()
+    assert ok is False
+    assert pkgs == []
+
+
+def test_install_missing_packages_none_missing(monkeypatch):
+    monkeypatch.setattr(preflight.os, "geteuid", lambda: 0)
+    monkeypatch.setattr(preflight.shutil, "which", lambda cmd: f"/usr/bin/{cmd}")
+    ok, pkgs = install_missing_packages()
+    assert ok is True
+    assert pkgs == []
+
+
+def test_install_missing_packages_success(monkeypatch):
+    from osx_proxmox_next.infrastructure import CommandResult
+    monkeypatch.setattr(preflight.os, "geteuid", lambda: 0)
+    present = {"sgdisk", "losetup", "mkfs.fat", "blkid"}
+    monkeypatch.setattr(
+        preflight.shutil, "which",
+        lambda cmd: f"/usr/bin/{cmd}" if cmd in present else None,
+    )
+    monkeypatch.setattr(Path, "exists", lambda self: False)
+    messages = []
+    captured_argv = []
+
+    class FakeAdapter:
+        def run(self, argv):
+            captured_argv.extend(argv)
+            return CommandResult(ok=True, returncode=0, output="")
+
+    ok, pkgs = install_missing_packages(on_output=messages.append, adapter=FakeAdapter())
+    assert ok is True
+    assert "dmg2img" in pkgs
+    assert "parted" in pkgs
+    assert any("Installing" in m for m in messages)
+    assert captured_argv[0] == "apt-get"
+    assert "install" in captured_argv
+    assert "-y" in captured_argv
+
+
+def test_install_missing_packages_apt_failure(monkeypatch):
+    from osx_proxmox_next.infrastructure import CommandResult
+    monkeypatch.setattr(preflight.os, "geteuid", lambda: 0)
+    monkeypatch.setattr(preflight.shutil, "which", lambda _cmd: None)
+    monkeypatch.setattr(Path, "exists", lambda self: False)
+
+    class FakeAdapter:
+        def run(self, argv):
+            return CommandResult(ok=False, returncode=1, output="E: Unable to locate package")
+
+    ok, pkgs = install_missing_packages(adapter=FakeAdapter())
+    assert ok is False
+    assert pkgs == []
+
+
+def test_install_missing_packages_command_not_found(monkeypatch):
+    from osx_proxmox_next.infrastructure import CommandResult
+    monkeypatch.setattr(preflight.os, "geteuid", lambda: 0)
+    monkeypatch.setattr(preflight.shutil, "which", lambda _cmd: None)
+    monkeypatch.setattr(Path, "exists", lambda self: False)
+
+    class FakeAdapter:
+        def run(self, argv):
+            return CommandResult(ok=False, returncode=127, output="Command not found: apt-get")
+
+    ok, pkgs = install_missing_packages(adapter=FakeAdapter())
+    assert ok is False
+    assert pkgs == []


### PR DESCRIPTION
## Summary
- Auto-install missing build dependencies (dmg2img, parted, gdisk, etc.) during preflight in both TUI and CLI
- Add Exit button to TUI wizard and post-install boot order hint
- Route all subprocess calls through ProxmoxAdapter for consistent error handling
- Fix multiple code quality issues from deep audit (type hints, exception chaining, input mutation, lazy init)

## Changes
- **preflight.py**: `install_missing_packages()`, `has_missing_build_deps()`, `find_missing_packages()` with DI support
- **app.py**: Auto-install in `_preflight_worker`, lazy `_get_pve()` singleton, direct `StepResult` attribute access, Exit button
- **cli.py**: Auto-install in `preflight` subcommand, deduplicated detection logic
- **downloader.py**: `_build_recovery_image` uses `ProxmoxAdapter` instead of raw `subprocess.run`
- **executor.py**: `Callable` from `collections.abc`
- **planner.py**: `build_plan` shallow-copies config before `_populate_smbios` mutation
- 448 tests, 99.17% coverage

## Testing
- [x] All 448 tests passing
- [x] 99.17% branch coverage
- [ ] Manual test on Proxmox node with missing deps