### PR TITLE
fix(install): expose osx-next-cli via /usr/local/bin after install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -52,8 +52,16 @@ setup_runtime() {
   pip install --upgrade pip >>"$LOG_FILE" 2>&1 || die "pip upgrade failed"
   pip install --force-reinstall --no-deps -e "$REPO_DIR" >>"$LOG_FILE" 2>&1 || die "editable install failed"
   pip install -e "$REPO_DIR" >>"$LOG_FILE" 2>&1 || die "dependency install failed"
-  ln -sf "$VENV_DIR/bin/osx-next" /usr/local/bin/osx-next
-  ln -sf "$VENV_DIR/bin/osx-next-cli" /usr/local/bin/osx-next-cli
+  _safe_venv_dir="$(realpath "$VENV_DIR" 2>/dev/null)" || die "Cannot resolve VENV_DIR path"
+  case "$_safe_venv_dir" in
+    /root/*|/opt/*) ;;
+    *) die "VENV_DIR '$_safe_venv_dir' is outside allowed paths (/root, /opt)" ;;
+  esac
+  [[ -x "$_safe_venv_dir/bin/osx-next" ]] || die "osx-next binary missing after install"
+  [[ -x "$_safe_venv_dir/bin/osx-next-cli" ]] || die "osx-next-cli binary missing after install"
+  ln -sf "$_safe_venv_dir/bin/osx-next" /usr/local/bin/osx-next || die "Failed to install osx-next to /usr/local/bin"
+  ln -sf "$_safe_venv_dir/bin/osx-next-cli" /usr/local/bin/osx-next-cli || die "Failed to install osx-next-cli to /usr/local/bin"
+  log "Installed osx-next and osx-next-cli to /usr/local/bin"
 }
 
 launch() {

--- a/install.sh
+++ b/install.sh
@@ -52,6 +52,8 @@ setup_runtime() {
   pip install --upgrade pip >>"$LOG_FILE" 2>&1 || die "pip upgrade failed"
   pip install --force-reinstall --no-deps -e "$REPO_DIR" >>"$LOG_FILE" 2>&1 || die "editable install failed"
   pip install -e "$REPO_DIR" >>"$LOG_FILE" 2>&1 || die "dependency install failed"
+  ln -sf "$VENV_DIR/bin/osx-next" /usr/local/bin/osx-next
+  ln -sf "$VENV_DIR/bin/osx-next-cli" /usr/local/bin/osx-next-cli
 }
 
 launch() {


### PR DESCRIPTION
## Summary

After installation, `osx-next-cli` was only available inside the venv session launched by the install script. Opening a new SSH session made the command unavailable.

Closes: related to #72 (user reported `osx-next-cli` not found after running install script)

## Changes

- Symlink `osx-next` and `osx-next-cli` into `/usr/local/bin` after pip install
- Validate `VENV_DIR` is under `/root` or `/opt` before symlinking (prevents path traversal via `OSX_NEXT_VENV_DIR` env var when running as root)
- Guard against missing binaries post-install with explicit existence checks
- Fail with clear error message if `/usr/local/bin` is not writable

## Pre-Flight Results

| Check | Result |
|-------|--------|
| Tests | PASS (826 passed) |
| Coverage | PASS (≥ 95%) |

## Testing

- [ ] Fresh install: verify `osx-next-cli --help` works in a new shell after running install script
- [ ] Re-install: verify symlinks are updated correctly
- [ ] Tampered `OSX_NEXT_VENV_DIR`: verify path validation blocks traversal