### PR TITLE
chore(readme): add GPU passthrough fund badge (for-the-badge style)

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,7 +640,7 @@ Enables pre-commit, commit-msg, and pre-push hooks for:
 
 - 🧩 **Multi-VM templates** — save and reuse configurations across VMs
 - 🔄 **Auto-update OpenCore** — detect and pull latest OpenCore releases
-- 🎮 **GPU passthrough wizard** — guided IOMMU + VFIO setup *(unlocks at $200 raised — see badge above)*
+- 🎮 **GPU passthrough wizard** — guided IOMMU + VFIO setup *(unlocks at $1000 raised — see badge above)*
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,11 @@
   <a href="https://buymeacoffee.com/lucidfabrics">
     <img alt="Buy Me a Coffee" src="https://img.shields.io/badge/Buy%20Me%20a%20Coffee-FFDD00?logo=buymeacoffee&logoColor=black">
   </a>
+</p>
+
+<p align="center">
   <a href="https://ko-fi.com/lucidfabrics">
-    <img alt="GPU passthrough fund" src="https://img.shields.io/endpoint?url=https://api.lucidfabrics.com/api/public/progress/osx-proxmox-next&style=for-the-badge">
+    <img alt="GPU Passthrough Fund progress" src="https://api.lucidfabrics.com/api/public/progress/osx-proxmox-next/svg" width="600">
   </a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@
   <a href="https://buymeacoffee.com/lucidfabrics">
     <img alt="Buy Me a Coffee" src="https://img.shields.io/badge/Buy%20Me%20a%20Coffee-FFDD00?logo=buymeacoffee&logoColor=black">
   </a>
+  <a href="https://ko-fi.com/lucidfabrics">
+    <img alt="GPU passthrough fund" src="https://img.shields.io/endpoint?url=https://api.lucidfabrics.com/api/public/progress/osx-proxmox-next&style=for-the-badge">
+  </a>
 </p>
 
 ---
@@ -637,7 +640,7 @@ Enables pre-commit, commit-msg, and pre-push hooks for:
 
 - 🧩 **Multi-VM templates** — save and reuse configurations across VMs
 - 🔄 **Auto-update OpenCore** — detect and pull latest OpenCore releases
-- 🎮 **GPU passthrough wizard** — guided IOMMU + VFIO setup *(unlocks at 20 sponsors)*
+- 🎮 **GPU passthrough wizard** — guided IOMMU + VFIO setup *(unlocks at $200 raised — see badge above)*
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds shields.io endpoint badge to README header showing Ko-fi + GitHub Sponsors progress toward \$200 GPU passthrough goal
- Uses `for-the-badge` style for better visibility
- Updates roadmap entry to reference the badge instead of "20 sponsors"

## Changes
- Added `<img>` badge linking to `https://api.lucidfabrics.com/api/public/progress/osx-proxmox-next`
- Updated roadmap GPU passthrough line to reflect dollar goal

## Testing
- Endpoint live: `curl https://api.lucidfabrics.com/api/public/progress/osx-proxmox-next` returns `{"message":"$5 / $200 (3%)","color":"lightgrey"}`
- Badge renders via shields.io endpoint format