### PR TITLE
chore(readme): add GPU fund badge + fix Xeon CI flake in net model test

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,11 @@
   <a href="https://buymeacoffee.com/lucidfabrics">
     <img alt="Buy Me a Coffee" src="https://img.shields.io/badge/Buy%20Me%20a%20Coffee-FFDD00?logo=buymeacoffee&logoColor=black">
   </a>
+</p>
+
+<p align="center">
   <a href="https://ko-fi.com/lucidfabrics">
-    <img alt="GPU passthrough fund" src="https://img.shields.io/endpoint?url=https://api.lucidfabrics.com/api/public/progress/osx-proxmox-next&style=for-the-badge">
+    <img alt="GPU Passthrough Fund progress" src="https://api.lucidfabrics.com/api/public/progress/osx-proxmox-next/svg" width="600">
   </a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@
   <a href="https://buymeacoffee.com/lucidfabrics">
     <img alt="Buy Me a Coffee" src="https://img.shields.io/badge/Buy%20Me%20a%20Coffee-FFDD00?logo=buymeacoffee&logoColor=black">
   </a>
+  <a href="https://ko-fi.com/lucidfabrics">
+    <img alt="GPU passthrough fund" src="https://img.shields.io/endpoint?url=https://api.lucidfabrics.com/api/public/progress/osx-proxmox-next&style=for-the-badge">
+  </a>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -38,12 +38,6 @@
   </a>
 </p>
 
-<p align="center">
-  <a href="https://ko-fi.com/lucidfabrics">
-    <img alt="GPU Passthrough Fund progress" src="https://api.lucidfabrics.com/api/public/progress/osx-proxmox-next/svg" width="600">
-  </a>
-</p>
-
 ---
 
 ## 🧰 Stop Wasting Afternoons on macOS VMs

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -91,10 +91,12 @@ def test_cli_plan_net_model_e1000(monkeypatch, capsys):
 def test_cli_plan_net_model_default_vmxnet3(monkeypatch, capsys):
     """Omitting --net-model defaults to vmxnet3 in plan output."""
     from osx_proxmox_next.assets import AssetCheck
+    import osx_proxmox_next.defaults as defaults_module
     monkeypatch.setattr(
         cli_module, "required_assets",
         lambda cfg: [AssetCheck("OC", Path("/tmp/oc.iso"), True, ""), AssetCheck("Rec", Path("/tmp/rec.iso"), True, "")],
     )
+    monkeypatch.setattr(defaults_module, "detect_net_model", lambda cpu: "vmxnet3")
     rc = run_cli(_plan_args())
     assert rc == 0
     captured = capsys.readouterr()


### PR DESCRIPTION
## Summary
Adds GPU passthrough fund progress badge (SVG progress bar) to README and fixes a CI flake where the default NIC model test failed on Xeon CI runners.

## Changes
- chore(readme): add GPU passthrough fund badge (for-the-badge style)
- chore(readme): replace text badge with SVG progress bar for GPU fund
- fix(tests): mock detect_net_model in vmxnet3 default test to avoid Xeon CI false negative

## Pre-Flight Results
| Check | Result |
|-------|--------|
| Tests | PASS (826 tests) |
| CI Fix | test_cli_plan_net_model_default_vmxnet3 — monkeypatched detect_net_model |

## Testing
- [x] 826 tests pass locally