### PR TITLE
feat(download): force re-download of OpenCore ISO + FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,9 @@ osx-next-cli --version
 # Download OpenCore + recovery images
 osx-next-cli download --macos ventura
 
+# Re-download the OpenCore ISO, ignoring any cached copy
+osx-next-cli download --macos ventura --force
+
 # Check host readiness
 osx-next-cli preflight
 
@@ -636,6 +639,51 @@ Enables pre-commit, commit-msg, and pre-push hooks for:
 - **Commit message validation** — enforces [conventional commits](https://www.conventionalcommits.org/) format
 - **Secret detection** — blocks hardcoded passwords, API keys, tokens
 - **Code quality warnings** — flags TODO/FIXME and debug `print()` statements
+
+---
+
+## ❓ FAQ
+
+### Can I pass through an NVIDIA GeForce GPU?
+
+No, not on any modern macOS. Apple dropped NVIDIA support years ago, and it never came back.
+
+| Architecture | Cards | Last macOS that worked |
+|---|---|---|
+| Kepler | GTX 600 / 700 | Big Sur 11 (native drivers) |
+| Maxwell | GTX 900 | High Sierra 10.13.6 (Web Drivers) |
+| Pascal | GTX 10-series, Titan Xp | High Sierra 10.13.6 (Web Drivers) |
+| Turing and newer | RTX 20 / 30 / 40 | Never supported |
+
+The newest GeForce card that ever ran on macOS was a **Pascal GTX 10-series**, and only up to **High Sierra**. NVIDIA's Web Drivers were never approved for Mojave or later, so anything Maxwell or newer is capped there. Kepler lasted longer only because real Macs shipped with it.
+
+For GPU passthrough on a current macOS guest (Ventura, Sonoma, Sequoia, Tahoe), use an **AMD** card instead. Polaris (RX 470/480/580), Vega, and Navi (RX 5000/6000) have native macOS drivers and work with WhateverGreen, which ships in the OpenCore image.
+
+### Why does macOS show "Memory Modules Misconfigured"?
+
+This is cosmetic and specific to the `MacPro7,1` SMBIOS. macOS knows the real Mac Pro has 12 RAM slots and expects them filled in groups, so a VM's flat memory layout trips the warning. Nothing is actually wrong with the VM.
+
+To silence it, add `RestrictEvents.kext` to `EFI/OC/Kexts/` and set the boot-arg `revpatch=memtab`. If you change the boot-arg and it has no effect, set it directly from macOS, because OpenCore only writes a value when one is not already present:
+
+```bash
+sudo nvram boot-args="revpatch=memtab"
+```
+
+Reboot afterward. Avoid changing the SMBIOS model to dodge the warning if you already have iCloud/iMessage working, since those are bound to the `MacPro7,1` identity.
+
+### My desktop wallpaper is white or blank
+
+This usually means macOS is running without GPU acceleration (the default `vga: std` framebuffer). Dynamic wallpapers in particular do not render in software mode. Pass through a supported AMD GPU for full acceleration, or pick a static wallpaper.
+
+### The CLI keeps using an old OpenCore image
+
+The OpenCore ISO is cached on disk and reused on every run. To pull a fresh copy, force it:
+
+```bash
+osx-next-cli download --macos <version> --force
+```
+
+In the TUI, tick **Force fresh download (ignore cached ISO)** on the Review step. Note this only refreshes the image for new installs; it does not modify the EFI of a VM you already created.
 
 ---
 

--- a/src/osx_proxmox_next/_wizard_mixin.py
+++ b/src/osx_proxmox_next/_wizard_mixin.py
@@ -146,10 +146,12 @@ class WizardStepsMixin:
                 log.debug("Failed to rebuild plan after download", exc_info=True)
             self._render_config_summary()  # type: ignore[attr-defined]
 
-    def _download_worker(self, config: VmConfig, missing: list[AssetCheck]) -> None:
+    def _download_worker(self, config: VmConfig, missing: list[AssetCheck],
+                         force_opencore: bool = False) -> None:
         def on_progress(phase: str, pct: int) -> None:
             self.call_from_thread(self._update_download_progress, phase, pct)  # type: ignore[attr-defined]
-        errors = run_download_worker(config, missing, on_progress=on_progress)
+        errors = run_download_worker(config, missing, on_progress=on_progress,
+                                     force_opencore=force_opencore)
         self.call_from_thread(self._finish_download, errors)  # type: ignore[attr-defined]
 
     def _update_download_progress(self, phase: str, pct: int) -> None:

--- a/src/osx_proxmox_next/app.py
+++ b/src/osx_proxmox_next/app.py
@@ -245,7 +245,8 @@ class NextApp(WizardStepsMixin, ManageModeMixin, EditModeMixin, App):
             self.query_one("#download_progress").remove_class("hidden")
             self.query_one("#download_progress", ProgressBar).update(total=100, progress=0)
             self.state.download_running = True
-            Thread(target=self._download_worker, args=(config, missing), daemon=True).start()
+            force = self.query_one("#force_download_cb", Checkbox).value
+            Thread(target=self._download_worker, args=(config, missing, force), daemon=True).start()
         else:
             self.query_one("#download_status", Static).update(
                 f"Missing assets: {', '.join(a.name for a in missing)}. Provide path manually."

--- a/src/osx_proxmox_next/cli.py
+++ b/src/osx_proxmox_next/cli.py
@@ -125,6 +125,8 @@ def _add_download_subparser(sub: argparse._SubParsersAction) -> None:
     dl.add_argument("--dest", type=str, default=DEFAULT_ISO_DIR, help="Destination directory")
     dl.add_argument("--opencore-only", action="store_true", help="Only download OpenCore ISO")
     dl.add_argument("--recovery-only", action="store_true", help="Only download recovery image")
+    dl.add_argument("--force", action="store_true",
+                    help="Ignore cached OpenCore ISO and re-download the newest one")
 
 
 def _add_vm_subparsers(sub: argparse._SubParsersAction, common: argparse.ArgumentParser) -> None:
@@ -430,7 +432,8 @@ def _run_download(args: argparse.Namespace) -> int:
     if not args.recovery_only:
         print(f"Downloading OpenCore image for {macos}...")
         try:
-            path = download_opencore(macos, dest_dir, on_progress=_cli_progress)
+            path = download_opencore(macos, dest_dir, on_progress=_cli_progress,
+                                     force=getattr(args, "force", False))
             print(f"\nDownloaded: {path}")
         except DownloadError as exc:
             print(f"\nOpenCore download failed: {exc}")

--- a/src/osx_proxmox_next/downloader.py
+++ b/src/osx_proxmox_next/downloader.py
@@ -62,15 +62,17 @@ def download_opencore(
     macos: str,
     dest_dir: Path,
     on_progress: ProgressCallback = None,
+    force: bool = False,
 ) -> Path:
     version = __version__
     # Try version-specific first, fall back to universal OC image
     candidates = [f"opencore-{macos}.iso", _OPENCORE_UNIVERSAL]
-    for name in candidates:
-        dest = dest_dir / name
-        if dest.exists():
-            log.debug("OpenCore cache hit: %s", dest)
-            return dest
+    if not force:
+        for name in candidates:
+            dest = dest_dir / name
+            if dest.exists():
+                log.debug("OpenCore cache hit: %s", dest)
+                return dest
 
     # Check version-tagged release, latest release, then permanent 'assets' tag
     releases = _fetch_github_releases(version)

--- a/src/osx_proxmox_next/screens/step_screens.py
+++ b/src/osx_proxmox_next/screens/step_screens.py
@@ -190,6 +190,11 @@ def compose_step5() -> ComposeResult:
         yield Static("Review & Dry Run")
         yield Static("", id="config_summary")
         yield Static("", id="download_status")
+        yield Checkbox("Force fresh download (ignore cached ISO)", value=False, id="force_download_cb")
+        yield Static(
+            "Re-fetches the OpenCore image. Does not modify any existing VM.",
+            id="force_download_hint", classes="hint",
+        )
         yield ProgressBar(total=100, show_eta=False, id="download_progress", classes="hidden")
         with Horizontal(classes="action_row"):
             yield Button("Run Dry Apply", id="dry_run_btn", disabled=True)

--- a/src/osx_proxmox_next/services/download_service.py
+++ b/src/osx_proxmox_next/services/download_service.py
@@ -18,11 +18,14 @@ def run_download_worker(
     config: VmConfig,
     missing: list[AssetCheck],
     on_progress: Callable[[str, int], None],
+    force_opencore: bool = False,
 ) -> list[str]:
     """Download missing assets and return a list of error strings.
 
     *on_progress(phase, pct)* is called on the background thread — callers
     that need to update UI must dispatch to the main thread themselves.
+
+    *force_opencore* bypasses the cached OpenCore ISO and re-downloads it.
     """
     dest_dir = Path(config.iso_dir or DEFAULT_ISO_DIR)
     errors: list[str] = []
@@ -37,7 +40,8 @@ def run_download_worker(
             continue
         if "OpenCore" in asset.name:
             try:
-                download_opencore(config.macos, dest_dir, on_progress=_progress_cb)
+                download_opencore(config.macos, dest_dir, on_progress=_progress_cb,
+                                  force=force_opencore)
             except DownloadError as exc:
                 errors.append(f"OpenCore: {exc}")
         elif "recovery" in asset.name.lower() or "installer" in asset.name.lower():  # pragma: no branch

--- a/tests/test_app_wizard.py
+++ b/tests/test_app_wizard.py
@@ -867,7 +867,7 @@ def test_download_worker_success(monkeypatch) -> None:
 
     download_calls = {"opencore": 0, "recovery": 0}
 
-    def fake_download_opencore(macos, dest, on_progress=None):
+    def fake_download_opencore(macos, dest, on_progress=None, force=False):
         download_calls["opencore"] += 1
         if on_progress:
             on_progress(DownloadProgress(downloaded=500, total=1000, phase="opencore"))
@@ -1783,7 +1783,7 @@ def test_download_worker_skips_non_downloadable(monkeypatch) -> None:
 
     download_calls = {"opencore": 0}
 
-    def fake_download_opencore(macos, dest, on_progress=None):
+    def fake_download_opencore(macos, dest, on_progress=None, force=False):
         download_calls["opencore"] += 1
         return dest / f"opencore-{macos}.iso"
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -89,14 +89,21 @@ def test_cli_plan_net_model_e1000(monkeypatch, capsys):
 
 
 def test_cli_plan_net_model_default_vmxnet3(monkeypatch, capsys):
-    """Omitting --net-model defaults to vmxnet3 in plan output."""
+    """Omitting --net-model defaults to vmxnet3 on a modern non-Xeon CPU."""
     from osx_proxmox_next.assets import AssetCheck
-    import osx_proxmox_next.defaults as defaults_module
+    from osx_proxmox_next.defaults import CpuInfo
     monkeypatch.setattr(
         cli_module, "required_assets",
         lambda cfg: [AssetCheck("OC", Path("/tmp/oc.iso"), True, ""), AssetCheck("Rec", Path("/tmp/rec.iso"), True, "")],
     )
-    monkeypatch.setattr(defaults_module, "detect_net_model", lambda cpu: "vmxnet3")
+    # Simulate a modern non-Xeon Intel CPU so the real detect_net_model logic
+    # runs and selects vmxnet3 (Xeon/pre-Skylake would pick e1000-82545em).
+    modern_cpu = CpuInfo(
+        vendor="Intel", model_name="Intel(R) Core(TM) i7-10700K",
+        family=6, model=165, needs_emulated_cpu=False,
+        needs_penryn=False, is_xeon=False,
+    )
+    monkeypatch.setattr(cli_module, "detect_cpu_info", lambda: modern_cpu)
     rc = run_cli(_plan_args())
     assert rc == 0
     captured = capsys.readouterr()
@@ -384,6 +391,36 @@ def test_auto_download_missing_opencore(monkeypatch, tmp_path):
     assert "oc" in downloaded
 
 
+def test_download_force_passes_through(monkeypatch, tmp_path):
+    """`download --force` forwards force=True into download_opencore."""
+    captured = {}
+
+    def fake_download_opencore(macos, dest_dir, on_progress=None, force=False):
+        captured["force"] = force
+        return tmp_path / "opencore-sequoia.iso"
+
+    monkeypatch.setattr(cli_module, "download_opencore", fake_download_opencore)
+    rc = run_cli(["download", "--macos", "sequoia", "--dest", str(tmp_path),
+                  "--opencore-only", "--force"])
+    assert rc == 0
+    assert captured["force"] is True
+
+
+def test_download_without_force_defaults_false(monkeypatch, tmp_path):
+    """Omitting --force keeps the cache-respecting default."""
+    captured = {}
+
+    def fake_download_opencore(macos, dest_dir, on_progress=None, force=False):
+        captured["force"] = force
+        return tmp_path / "opencore-sequoia.iso"
+
+    monkeypatch.setattr(cli_module, "download_opencore", fake_download_opencore)
+    rc = run_cli(["download", "--macos", "sequoia", "--dest", str(tmp_path),
+                  "--opencore-only"])
+    assert rc == 0
+    assert captured["force"] is False
+
+
 def test_auto_download_missing_recovery(monkeypatch, tmp_path):
     from osx_proxmox_next.cli import _auto_download_missing
     from osx_proxmox_next.assets import AssetCheck
@@ -487,7 +524,7 @@ def test_auto_download_missing_nothing_downloadable(monkeypatch, tmp_path):
 def test_cli_download_success(monkeypatch, tmp_path):
     monkeypatch.setattr(
         cli_module, "download_opencore",
-        lambda macos, dest, on_progress=None: tmp_path / f"opencore-{macos}.iso",
+        lambda macos, dest, on_progress=None, force=False: tmp_path / f"opencore-{macos}.iso",
     )
     monkeypatch.setattr(
         cli_module, "download_recovery",
@@ -500,7 +537,7 @@ def test_cli_download_success(monkeypatch, tmp_path):
 def test_cli_download_opencore_only(monkeypatch, tmp_path):
     monkeypatch.setattr(
         cli_module, "download_opencore",
-        lambda macos, dest, on_progress=None: tmp_path / f"opencore-{macos}.iso",
+        lambda macos, dest, on_progress=None, force=False: tmp_path / f"opencore-{macos}.iso",
     )
     rc = run_cli(["download", "--macos", "sequoia", "--dest", str(tmp_path), "--opencore-only"])
     assert rc == 0
@@ -519,7 +556,7 @@ def test_cli_download_failure(monkeypatch, tmp_path):
     from osx_proxmox_next.downloader import DownloadError
     monkeypatch.setattr(
         cli_module, "download_opencore",
-        lambda macos, dest, on_progress=None: (_ for _ in ()).throw(DownloadError("fail")),
+        lambda macos, dest, on_progress=None, force=False: (_ for _ in ()).throw(DownloadError("fail")),
     )
     monkeypatch.setattr(
         cli_module, "download_recovery",

--- a/tests/test_download_service.py
+++ b/tests/test_download_service.py
@@ -52,8 +52,8 @@ def test_run_download_worker_empty_missing_returns_no_errors(monkeypatch) -> Non
 def test_run_download_worker_opencore_calls_download_opencore(monkeypatch) -> None:
     called = []
 
-    def fake_download_opencore(macos, dest_dir, on_progress=None):
-        called.append(("opencore", macos))
+    def fake_download_opencore(macos, dest_dir, on_progress=None, force=False):
+        called.append(("opencore", macos, force))
 
     monkeypatch.setattr(
         "osx_proxmox_next.services.download_service.download_opencore",
@@ -64,6 +64,26 @@ def test_run_download_worker_opencore_calls_download_opencore(monkeypatch) -> No
     )
     assert errors == []
     assert any(c[0] == "opencore" for c in called)
+    # Default leaves the cache-respecting behavior intact.
+    assert all(c[2] is False for c in called if c[0] == "opencore")
+
+
+def test_run_download_worker_force_opencore_passthrough(monkeypatch) -> None:
+    called = []
+
+    def fake_download_opencore(macos, dest_dir, on_progress=None, force=False):
+        called.append(("opencore", macos, force))
+
+    monkeypatch.setattr(
+        "osx_proxmox_next.services.download_service.download_opencore",
+        fake_download_opencore,
+    )
+    errors = run_download_worker(
+        _make_config(), [_asset("OpenCore image")], _noop_progress,
+        force_opencore=True,
+    )
+    assert errors == []
+    assert any(c[0] == "opencore" and c[2] is True for c in called)
 
 
 def test_run_download_worker_recovery_calls_download_recovery(monkeypatch) -> None:
@@ -108,7 +128,7 @@ def test_run_download_worker_installer_calls_download_recovery(monkeypatch) -> N
 def test_run_download_worker_opencore_download_error_returns_error_string(
     monkeypatch,
 ) -> None:
-    def bad_download_opencore(macos, dest_dir, on_progress=None):
+    def bad_download_opencore(macos, dest_dir, on_progress=None, force=False):
         raise DownloadError("network timeout")
 
     monkeypatch.setattr(
@@ -142,7 +162,7 @@ def test_run_download_worker_recovery_download_error_returns_error_string(
 
 
 def test_run_download_worker_does_not_raise_on_download_error(monkeypatch) -> None:
-    def bad_download_opencore(macos, dest_dir, on_progress=None):
+    def bad_download_opencore(macos, dest_dir, on_progress=None, force=False):
         raise DownloadError("fail")
 
     monkeypatch.setattr(
@@ -186,7 +206,7 @@ def test_run_download_worker_skips_non_downloadable_assets(monkeypatch) -> None:
 def test_run_download_worker_progress_callback_called(monkeypatch) -> None:
     progress_calls = []
 
-    def fake_download_opencore(macos, dest_dir, on_progress=None):
+    def fake_download_opencore(macos, dest_dir, on_progress=None, force=False):
         from osx_proxmox_next.downloader import DownloadProgress
         if on_progress:
             on_progress(DownloadProgress(phase="opencore", downloaded=50, total=100))
@@ -209,7 +229,7 @@ def test_run_download_worker_progress_callback_called(monkeypatch) -> None:
 def test_run_download_worker_uses_config_iso_dir(monkeypatch) -> None:
     seen_dirs = []
 
-    def fake_download_opencore(macos, dest_dir, on_progress=None):
+    def fake_download_opencore(macos, dest_dir, on_progress=None, force=False):
         seen_dirs.append(dest_dir)
 
     monkeypatch.setattr(

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -145,6 +145,31 @@ class TestDownloadOpencore:
         result = download_opencore("sequoia", tmp_path)
         assert result == existing
 
+    def test_force_ignores_cache_and_redownloads(self, tmp_path, monkeypatch):
+        """force=True bypasses the cached ISO and fetches a fresh copy."""
+        existing = tmp_path / "opencore-sequoia.iso"
+        existing.write_text("stale cached iso")
+
+        release = {
+            "tag_name": "v0.3.0",
+            "assets": [
+                {
+                    "name": "opencore-sequoia.iso",
+                    "browser_download_url": "https://example.com/opencore-sequoia.iso",
+                }
+            ],
+        }
+        monkeypatch.setattr(dl_module, "_fetch_github_releases", lambda v: [release])
+        fresh = b"fresh-iso-content"
+        file_resp = _make_chunked_response([fresh], len(fresh))
+        monkeypatch.setattr(dl_module.urllib.request, "urlopen", lambda req, timeout=None: file_resp)
+        monkeypatch.setattr(dl_module, "__version__", "0.3.0")
+        monkeypatch.setattr(dl_module.time, "sleep", lambda s: None)
+
+        result = download_opencore("sequoia", tmp_path, force=True)
+        assert result == existing
+        assert result.read_bytes() == fresh
+
 
 class TestDownloadRecovery:
     def test_tahoe_uses_osrecovery_with_latest(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
Adds a way to force a fresh re-download of the OpenCore ISO, bypassing the on-disk cache, plus a README FAQ covering common questions (GeForce support, the "Memory Modules Misconfigured" warning, white wallpaper, and stale ISO cache).

## Changes
- **`download --force`** — new CLI flag on the `download` subcommand; bypasses the cache-hit in `download_opencore` and re-fetches the ISO
- **TUI checkbox** — "Force fresh download (ignore cached ISO)" on the Review step, wired through `_download_worker` → `run_download_worker` → `download_opencore`
- **README FAQ** — new section answering NVIDIA GeForce support (Pascal/High Sierra ceiling, use AMD), the MacPro7,1 memory warning + RestrictEvents/`revpatch=memtab` fix, white wallpaper cause, and the new `--force` flag

## Why
The OpenCore ISO is cached on disk and reused on every run with no version check, so users couldn't pull a newer image without manually deleting the cache. The force flag makes refresh explicit and safe (it only touches the ISO, never an existing VM's EFI).

## Pre-Flight Results
| Check | Result |
|-------|--------|
| Tests | PASS (830 passed) |
| Coverage | PASS (≥95%, repo gate) |

## Testing
- [x] `pytest` green, coverage ≥95%
- Added: `download --force` passthrough tests (CLI + service), cache-bypass test, TUI mock-signature updates