### PR TITLE
feat(cli): add post-install subcommand to fix boot order after macOS installation

### DIFF
--- a/src/osx_proxmox_next/cli.py
+++ b/src/osx_proxmox_next/cli.py
@@ -14,7 +14,7 @@ from .doctor import run_doctor, Severity
 from .domain import MIN_VMID, MAX_VMID, SUPPORTED_MACOS, VmConfig, EditChanges, validate_config, validate_edit_changes
 from .downloader import DownloadError, DownloadProgress, download_opencore, download_recovery
 from .executor import apply_plan
-from .planner import build_plan, build_destroy_plan, build_edit_plan, build_clone_plan
+from .planner import build_plan, build_destroy_plan, build_edit_plan, build_clone_plan, build_post_install_plan, POST_INSTALL_BOOT_ORDER
 from .services import fetch_vm_info, get_proxmox_adapter, run_download_worker
 from .script_renderer import render_script
 from .preflight import run_preflight, has_missing_build_deps, install_missing_packages
@@ -117,6 +117,12 @@ def _add_simple_subparsers(sub: argparse._SubParsersAction) -> None:
     guide.add_argument("reason", nargs="?", default="boot issue")
     doctor = sub.add_parser("doctor", help="Diagnose a running or stopped macOS VM for common config issues")
     doctor.add_argument("--vmid", type=int, required=True, help="VM ID to inspect")
+    post_install = sub.add_parser(
+        "post-install",
+        help="Fix boot order after macOS installation (switches to OpenCore-first: ide0;virtio0)",
+    )
+    post_install.add_argument("--vmid", type=int, required=True, help="VM ID to update")
+    post_install.add_argument("--execute", action="store_true", help="Actually run (default is dry run)")
 
 
 def _add_download_subparser(sub: argparse._SubParsersAction) -> None:
@@ -220,9 +226,9 @@ def _handle_apply_command(args: argparse.Namespace, config: VmConfig, steps: lis
     if result.ok:
         print(f"Apply OK. Log: {result.log_path}")
         print()
-        print("POST-INSTALL: After macOS finishes installing, fix the boot order")
-        print("so the main disk boots first (instead of recovery):")
-        print(f"  qm set {config.vmid} --boot order=virtio0;ide0")
+        print("POST-INSTALL: After macOS finishes installing, run:")
+        print(f"  osx-next-cli post-install --vmid {config.vmid} --execute")
+        print(f"This switches boot order to {POST_INSTALL_BOOT_ORDER} (OpenCore first).")
         print()
         print("If this saved you time: https://ko-fi.com/lucidfabrics | https://buymeacoffee.com/lucidfabrics")
         return 0
@@ -263,6 +269,8 @@ def _dispatch_simple_commands(args: argparse.Namespace) -> int | None:
         return _run_edit(args)
     if args.cmd == "clone":
         return _run_clone(args)
+    if args.cmd == "post-install":
+        return _run_post_install(args)
     return None
 
 
@@ -572,6 +580,31 @@ def _run_clone(args: argparse.Namespace) -> int:
 
     print(f"\nClone FAILED. Log: {result.log_path}")
     return 8
+
+
+def _run_post_install(args: argparse.Namespace) -> int:
+    vmid = args.vmid
+    if vmid < MIN_VMID or vmid > MAX_VMID:
+        print(f"ERROR: VMID must be between {MIN_VMID} and {MAX_VMID}.")
+        return 2
+
+    steps = build_post_install_plan(vmid)
+
+    if not args.execute:
+        print("DRY RUN — pass --execute to apply:\n")
+        for idx, step in enumerate(steps, start=1):
+            print(f"{idx:02d}. {step.title}")
+            print(f"    {step.command}")
+        return 0
+
+    result = apply_plan(steps, execute=True)
+    if result.ok:
+        print(f"Post-install OK. Boot order set to {POST_INSTALL_BOOT_ORDER}. Log: {result.log_path}")
+        print("Start the VM to boot into installed macOS via OpenCore.")
+        return 0
+
+    print(f"Post-install FAILED. Log: {result.log_path}")
+    return 9
 
 
 if __name__ == "__main__":

--- a/src/osx_proxmox_next/planner.py
+++ b/src/osx_proxmox_next/planner.py
@@ -19,6 +19,7 @@ from .smbios_planner import (
     _populate_smbios,
 )
 
+POST_INSTALL_BOOT_ORDER = "order=ide0;virtio0"
 
 def _cpu_args(cpu: CpuInfo, override: str = "") -> str:
     """Return QEMU -cpu flag tailored to host CPU.
@@ -296,6 +297,21 @@ def _boot_steps(config: VmConfig, vmid: str) -> list[PlanStep]:
             title="Start VM",
             argv=["qm", "start", vmid],
             risk="action",
+        ),
+    ]
+
+
+def build_post_install_plan(vmid: int) -> list[PlanStep]:
+    """Fix boot order after macOS installation completes.
+
+    Switches from recovery-first (ide2;virtio0;ide0) to OpenCore-first
+    (ide0;virtio0) so the VM boots into the installed macOS via OpenCore.
+    """
+    vid = str(vmid)
+    return [
+        PlanStep(
+            title="Set post-install boot order",
+            argv=["qm", "set", vid, "--boot", POST_INSTALL_BOOT_ORDER],
         ),
     ]
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from osx_proxmox_next import cli as cli_module
 from osx_proxmox_next.cli import run_cli
+from osx_proxmox_next.planner import POST_INSTALL_BOOT_ORDER
 
 
 def test_cli_parser_has_expected_commands() -> None:
@@ -1171,3 +1172,80 @@ def test_cli_clone_execute_no_apple_services_no_message(monkeypatch, tmp_path, c
     assert rc == 0
     out = capsys.readouterr().out
     assert "Apple services" not in out
+
+
+# ---------------------------------------------------------------------------
+# post-install subcommand
+# ---------------------------------------------------------------------------
+
+def test_cli_parser_has_post_install_command() -> None:
+    from osx_proxmox_next.cli import build_parser
+    parser = build_parser()
+    cmds = parser._subparsers._group_actions[0].choices  # type: ignore[attr-defined]
+    assert "post-install" in cmds
+
+
+def test_cli_post_install_dry_run(capsys) -> None:
+    rc = run_cli(["post-install", "--vmid", "102"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "DRY RUN" in out
+    assert POST_INSTALL_BOOT_ORDER in out
+
+
+def test_cli_post_install_invalid_vmid(capsys) -> None:
+    rc = run_cli(["post-install", "--vmid", "1"])
+    assert rc == 2
+    assert "VMID" in capsys.readouterr().out
+
+
+def test_cli_post_install_execute_success(monkeypatch, tmp_path, capsys) -> None:
+    from osx_proxmox_next.executor import ApplyResult
+    monkeypatch.setattr(
+        cli_module, "apply_plan",
+        lambda steps, execute=False: ApplyResult(ok=True, results=[], log_path=tmp_path / "log.txt"),
+    )
+    rc = run_cli(["post-install", "--vmid", "102", "--execute"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Post-install OK" in out
+    assert POST_INSTALL_BOOT_ORDER in out
+
+
+def test_cli_post_install_execute_failure(monkeypatch, tmp_path, capsys) -> None:
+    from osx_proxmox_next.executor import ApplyResult
+    monkeypatch.setattr(
+        cli_module, "apply_plan",
+        lambda steps, execute=False: ApplyResult(ok=False, results=[], log_path=tmp_path / "log.txt"),
+    )
+    rc = run_cli(["post-install", "--vmid", "102", "--execute"])
+    assert rc == 9
+    assert "FAILED" in capsys.readouterr().out
+
+
+def test_cli_apply_post_install_hint_correct(monkeypatch, tmp_path, capsys) -> None:
+    """Apply success message must reference post-install subcommand, not raw qm set."""
+    from osx_proxmox_next.assets import AssetCheck
+    from osx_proxmox_next.executor import ApplyResult
+    from osx_proxmox_next.rollback import RollbackSnapshot
+
+    monkeypatch.setattr(
+        cli_module, "required_assets",
+        lambda cfg: [AssetCheck("OC", Path("/tmp/oc.iso"), True, "")],
+    )
+    monkeypatch.setattr(cli_module, "create_snapshot",
+                        lambda vmid: RollbackSnapshot(vmid=vmid, path=tmp_path / "snap.json"))
+    monkeypatch.setattr(
+        cli_module, "apply_plan",
+        lambda steps, execute=False: ApplyResult(ok=True, results=[], log_path=tmp_path / "log.txt"),
+    )
+    rc = run_cli([
+        "apply", "--vmid", "102", "--name", "macos-tahoe",
+        "--macos", "sequoia", "--cores", "8", "--memory", "16384",
+        "--disk", "128", "--bridge", "vmbr0", "--storage", "local-lvm",
+    ])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "post-install" in out
+    assert POST_INSTALL_BOOT_ORDER in out
+    assert "virtio0;ide0" not in out

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -3,6 +3,7 @@ from osx_proxmox_next.domain import VmConfig
 from osx_proxmox_next.planner import (
     build_plan, _cpu_args,
     VmInfo, fetch_vm_info, build_destroy_plan,
+    POST_INSTALL_BOOT_ORDER,
 )
 from osx_proxmox_next.script_renderer import (
     render_script, _plist_patch_script,
@@ -829,3 +830,26 @@ def test_build_plan_intel_host_no_kvm_pv_flags(monkeypatch) -> None:
     assert "kvm_pv_unhalt" not in profile.command
     assert "kvm_pv_eoi" not in profile.command
     assert "-cpu host" in profile.command
+
+
+# ---------------------------------------------------------------------------
+# build_post_install_plan
+# ---------------------------------------------------------------------------
+
+def test_build_post_install_plan_single_step() -> None:
+    from osx_proxmox_next.planner import build_post_install_plan
+    steps = build_post_install_plan(102)
+    assert len(steps) == 1
+    assert steps[0].title == "Set post-install boot order"
+
+
+def test_build_post_install_plan_correct_boot_order() -> None:
+    from osx_proxmox_next.planner import build_post_install_plan
+    steps = build_post_install_plan(102)
+    assert f"--boot '{POST_INSTALL_BOOT_ORDER}'" in steps[0].command
+
+
+def test_build_post_install_plan_targets_correct_vmid() -> None:
+    from osx_proxmox_next.planner import build_post_install_plan
+    steps = build_post_install_plan(999)
+    assert "qm set 999" in steps[0].command


### PR DESCRIPTION
## Summary

Adds `osx-next-cli post-install --vmid <ID> [--execute]` subcommand that sets the correct boot order (`ide0;virtio0`) after macOS installation completes. Fixes the pre-existing wrong hint that suggested `virtio0;ide0`, which skipped OpenCore as the EFI chainloader and caused VMs to stall on first boot.

Closes #78
Resolves #77

## Changes

- `feat(cli)`: new `post-install` subcommand with dry-run + execute modes, exit code 9 on failure
- `feat(planner)`: `build_post_install_plan(vmid)` — single step setting `order=ide0;virtio0`
- `fix(cli)`: replace wrong post-apply hint (`virtio0;ide0`) with reference to `post-install` subcommand
- `refactor(planner)`: extract `POST_INSTALL_BOOT_ORDER` constant to eliminate magic string duplication
- `test`: 9 new tests covering planner plan shape, CLI dry-run, execute success/failure, invalid VMID, and hint correctness

## Pre-Flight Results

| Check | Result |
|-------|--------|
| Deep Audit | PASS (arch: 71, quality: 84, security: 96) — MiniMax M3 × 10 rounds |
| Tests | PASS (839 passed) |
| Coverage | PASS (≥95%) |
| Code Review | PASS (0 high, 0 critical) |

## Testing

- [ ] Run `osx-next-cli post-install --vmid <ID>` (dry-run, verify output shows correct order)
- [ ] Run `osx-next-cli post-install --vmid <ID> --execute` on a real PVE node after installation
- [ ] Verify VM boots into OpenCore picker after command runs