### PR TITLE
feat(support): focus donation asks on peak success moments

### DIFF
--- a/src/osx_proxmox_next/assets.py
+++ b/src/osx_proxmox_next/assets.py
@@ -48,7 +48,7 @@ def required_assets(config: VmConfig) -> list[AssetCheck]:
 def suggested_fetch_commands(config: VmConfig) -> list[str]:
     iso_root = config.iso_dir or DEFAULT_ISO_DIR
     return [
-        f"# Auto-download available — run: osx-next-cli download --macos {config.macos}",
+        f"# Auto-download available - run: osx-next-cli download --macos {config.macos}",
         f"# Or manually place OpenCore image at {iso_root}/opencore-{config.macos}.iso",
         f"# Or place recovery image at {iso_root}/{config.macos}-recovery.iso",
     ]

--- a/src/osx_proxmox_next/cli.py
+++ b/src/osx_proxmox_next/cli.py
@@ -19,6 +19,7 @@ from .services import fetch_vm_info, get_proxmox_adapter, run_download_worker
 from .script_renderer import render_script
 from .preflight import run_preflight, has_missing_build_deps, install_missing_packages
 from .rollback import create_snapshot, rollback_hints
+from .support import SUPPORT_LINE, SUPPORT_LINES_POST_INSTALL
 
 _MB = 1024 * 1024
 
@@ -179,7 +180,7 @@ def _add_vm_subparsers(sub: argparse._SubParsersAction, common: argparse.Argumen
                        help="macOS version hint for SMBIOS model selection (default: sequoia)")
     clone.add_argument("--no-apple-services", action="store_true", default=False,
                        dest="no_apple_services",
-                       help="Skip vmgenid and MAC regeneration (not recommended — breaks Apple services isolation)")
+                       help="Skip vmgenid and MAC regeneration (not recommended - breaks Apple services isolation)")
     clone.add_argument("--execute", action="store_true",
                        help="Actually run (default is dry run)")
 
@@ -230,7 +231,7 @@ def _handle_apply_command(args: argparse.Namespace, config: VmConfig, steps: lis
         print(f"  osx-next-cli post-install --vmid {config.vmid} --execute")
         print(f"This switches boot order to {POST_INSTALL_BOOT_ORDER} (OpenCore first).")
         print()
-        print("If this saved you time: https://ko-fi.com/lucidfabrics | https://buymeacoffee.com/lucidfabrics")
+        print(SUPPORT_LINE)
         return 0
 
     print(f"Apply FAILED. Log: {result.log_path}")
@@ -328,7 +329,7 @@ def _run_doctor(args: argparse.Namespace) -> int:
     failures = 0
     warnings = 0
 
-    print(f"\nDoctor report — VM {vmid}\n")
+    print(f"\nDoctor report - VM {vmid}\n")
     for check in checks:
         icon = _ICONS[check.severity]
         print(f"  [{icon}] {check.message}")
@@ -495,7 +496,7 @@ def _run_edit(args: argparse.Namespace) -> int:
     steps = build_edit_plan(vmid, changes, start_after=args.start, current_net0=current_net0)
 
     if not args.execute:
-        print("DRY RUN — pass --execute to apply:\n")
+        print("DRY RUN - pass --execute to apply:\n")
 
     for idx, step in enumerate(steps, start=1):
         print(f"{idx:02d}. {step.title}")
@@ -561,7 +562,7 @@ def _run_clone(args: argparse.Namespace) -> int:
     )
 
     if not args.execute:
-        print("DRY RUN — pass --execute to apply:\n")
+        print("DRY RUN - pass --execute to apply:\n")
 
     for idx, step in enumerate(steps, start=1):
         print(f"{idx:02d}. {step.title}")
@@ -576,6 +577,8 @@ def _run_clone(args: argparse.Namespace) -> int:
         print(f"VM {dst_vmid} is ready with a fresh SMBIOS identity.")
         if apple_services:
             print("Apple services (iMessage, FaceTime, iCloud) are isolated from the source VM.")
+        print()
+        print(SUPPORT_LINE)
         return 0
 
     print(f"\nClone FAILED. Log: {result.log_path}")
@@ -591,7 +594,7 @@ def _run_post_install(args: argparse.Namespace) -> int:
     steps = build_post_install_plan(vmid)
 
     if not args.execute:
-        print("DRY RUN — pass --execute to apply:\n")
+        print("DRY RUN - pass --execute to apply:\n")
         for idx, step in enumerate(steps, start=1):
             print(f"{idx:02d}. {step.title}")
             print(f"    {step.command}")
@@ -601,6 +604,9 @@ def _run_post_install(args: argparse.Namespace) -> int:
     if result.ok:
         print(f"Post-install OK. Boot order set to {POST_INSTALL_BOOT_ORDER}. Log: {result.log_path}")
         print("Start the VM to boot into installed macOS via OpenCore.")
+        print()
+        for line in SUPPORT_LINES_POST_INSTALL:
+            print(line)
         return 0
 
     print(f"Post-install FAILED. Log: {result.log_path}")

--- a/src/osx_proxmox_next/doctor.py
+++ b/src/osx_proxmox_next/doctor.py
@@ -44,11 +44,11 @@ def _net_model_from_value(net_value: str) -> str:
 def _check_balloon(cfg: dict[str, str], vmid: int) -> DoctorCheck:
     val = cfg.get("balloon", "")
     if val == "0":
-        return DoctorCheck("balloon", Severity.OK, "balloon=0 — macOS has no balloon driver")
+        return DoctorCheck("balloon", Severity.OK, "balloon=0 - macOS has no balloon driver")
     return DoctorCheck(
         "balloon",
         Severity.FAIL,
-        f"balloon={val or 'not set'} — macOS will crash with balloon driver enabled",
+        f"balloon={val or 'not set'} - macOS will crash with balloon driver enabled",
         fix=f"qm set {vmid} --balloon 0",
     )
 
@@ -60,7 +60,7 @@ def _check_machine(cfg: dict[str, str], vmid: int) -> DoctorCheck:
     return DoctorCheck(
         "machine",
         Severity.FAIL,
-        f"machine={val or 'not set'} — macOS requires q35",
+        f"machine={val or 'not set'} - macOS requires q35",
         fix=f"qm set {vmid} --machine q35",
     )
 
@@ -70,14 +70,14 @@ def _check_cores(cfg: dict[str, str], vmid: int) -> DoctorCheck:
     try:
         n = int(raw)
     except (ValueError, TypeError):
-        return DoctorCheck("cores", Severity.WARN, "cores not set — using Proxmox default")
+        return DoctorCheck("cores", Severity.WARN, "cores not set - using Proxmox default")
     if _is_power_of_two(n):
-        return DoctorCheck("cores", Severity.OK, f"cores={n} — power-of-2, safe for macOS")
+        return DoctorCheck("cores", Severity.OK, f"cores={n} - power-of-2, safe for macOS")
     nearest = 2 ** round(math.log2(n))
     return DoctorCheck(
         "cores",
         Severity.FAIL,
-        f"cores={n} — non-power-of-2 value hangs macOS at Apple logo",
+        f"cores={n} - non-power-of-2 value hangs macOS at Apple logo",
         fix=f"qm set {vmid} --cores {nearest}",
     )
 
@@ -92,7 +92,7 @@ def _check_memory(cfg: dict[str, str], vmid: int) -> DoctorCheck:
         return DoctorCheck(
             "memory",
             Severity.WARN,
-            f"memory={mb} MB — macOS installer needs at least 4096 MB",
+            f"memory={mb} MB - macOS installer needs at least 4096 MB",
             fix=f"qm set {vmid} --memory 4096",
         )
     return DoctorCheck("memory", Severity.OK, f"memory={mb} MB")
@@ -104,7 +104,7 @@ def _check_cpu(cfg: dict[str, str]) -> DoctorCheck:
         return DoctorCheck(
             "cpu",
             Severity.WARN,
-            f"cpu={val or 'not set'} — kvm64/kvm32 may cause boot failures; expected host or Cascadelake-Server",
+            f"cpu={val or 'not set'} - kvm64/kvm32 may cause boot failures; expected host or Cascadelake-Server",
         )
     return DoctorCheck("cpu", Severity.OK, f"cpu={val}")
 
@@ -116,11 +116,11 @@ def _check_net(cfg: dict[str, str], vmid: int) -> DoctorCheck:
     model = _net_model_from_value(net_val)
     good = ("vmxnet3", "e1000", "e1000-82545em")
     if any(model.startswith(m) for m in good):
-        return DoctorCheck("net0", Severity.OK, f"net0 model={model} — native macOS driver")
+        return DoctorCheck("net0", Severity.OK, f"net0 model={model} - native macOS driver")
     return DoctorCheck(
         "net0",
         Severity.FAIL,
-        f"net0 model={model} — macOS has no driver for this NIC; use vmxnet3 or e1000",
+        f"net0 model={model} - macOS has no driver for this NIC; use vmxnet3 or e1000",
         fix=f"qm set {vmid} --net0 vmxnet3,bridge=vmbr0,firewall=0",
     )
 
@@ -128,11 +128,11 @@ def _check_net(cfg: dict[str, str], vmid: int) -> DoctorCheck:
 def _check_agent(cfg: dict[str, str], vmid: int) -> DoctorCheck:
     val = cfg.get("agent", "")
     if "enabled=1" in val:
-        return DoctorCheck("agent", Severity.OK, "agent=enabled — graceful shutdown works")
+        return DoctorCheck("agent", Severity.OK, "agent=enabled - graceful shutdown works")
     return DoctorCheck(
         "agent",
         Severity.WARN,
-        "agent not enabled — graceful shutdown won't work without qemu-guest-agent in macOS",
+        "agent not enabled - graceful shutdown won't work without qemu-guest-agent in macOS",
         fix=f"qm set {vmid} --agent enabled=1",
     )
 
@@ -140,18 +140,18 @@ def _check_agent(cfg: dict[str, str], vmid: int) -> DoctorCheck:
 def _check_smbios(cfg: dict[str, str]) -> DoctorCheck:
     val = cfg.get("smbios1", "")
     if val and "uuid=" in val:
-        return DoctorCheck("smbios1", Severity.OK, "smbios1 set — identity chain configured")
+        return DoctorCheck("smbios1", Severity.OK, "smbios1 set - identity chain configured")
     return DoctorCheck(
         "smbios1",
         Severity.WARN,
-        "smbios1 not set — Apple services (iMessage, FaceTime, iCloud) won't work",
+        "smbios1 not set - Apple services (iMessage, FaceTime, iCloud) won't work",
     )
 
 
 def _check_disk(cfg: dict[str, str], key: str, label: str) -> DoctorCheck:
     if key in cfg:
-        return DoctorCheck(key, Severity.OK, f"{key} present — {label}")
-    return DoctorCheck(key, Severity.WARN, f"{key} not found — {label} may be missing")
+        return DoctorCheck(key, Severity.OK, f"{key} present - {label}")
+    return DoctorCheck(key, Severity.WARN, f"{key} not found - {label} may be missing")
 
 
 def _check_boot_order(cfg: dict[str, str], vmid: int) -> DoctorCheck:
@@ -160,12 +160,12 @@ def _check_boot_order(cfg: dict[str, str], vmid: int) -> DoctorCheck:
         return DoctorCheck(
             "boot",
             Severity.FAIL,
-            "boot order references ide3 — that device doesn't exist and blocks boot",
+            "boot order references ide3 - that device doesn't exist and blocks boot",
             fix=f"qm set {vmid} --boot order=ide2;virtio0;ide0",
         )
     if boot_val:
         return DoctorCheck("boot", Severity.OK, f"boot={boot_val}")
-    return DoctorCheck("boot", Severity.WARN, "boot order not set — Proxmox using firmware default")
+    return DoctorCheck("boot", Severity.WARN, "boot order not set - Proxmox using firmware default")
 
 
 def run_doctor(vmid: int, adapter: ProxmoxAdapter | None = None) -> list[DoctorCheck]:

--- a/src/osx_proxmox_next/preflight.py
+++ b/src/osx_proxmox_next/preflight.py
@@ -52,7 +52,7 @@ _BUILD_BINARIES: dict[str, str] = {
 
 
 def _check_ignore_msrs(kvm_conf: Path | None = None) -> PreflightCheck:
-    """Check if KVM ignore_msrs=Y is set — critical for macOS (prevents MSR kernel panics)."""
+    """Check if KVM ignore_msrs=Y is set - critical for macOS (prevents MSR kernel panics)."""
     if kvm_conf is None:
         kvm_conf = Path("/etc/modprobe.d/kvm.conf")
     if kvm_conf.exists():
@@ -66,13 +66,13 @@ def _check_ignore_msrs(kvm_conf: Path | None = None) -> PreflightCheck:
     return PreflightCheck(
         name="KVM ignore_msrs",
         ok=False,
-        details="Missing ignore_msrs=Y — macOS will kernel panic on unsupported MSR access. "
+        details="Missing ignore_msrs=Y - macOS will kernel panic on unsupported MSR access. "
                 "Fix: echo 'options kvm ignore_msrs=Y' >> /etc/modprobe.d/kvm.conf && update-initramfs -k all -u",
     )
 
 
 def _check_iommu(cmdline_path: Path | None = None) -> PreflightCheck:
-    """Check if IOMMU is enabled in kernel cmdline — informational (GPU passthrough)."""
+    """Check if IOMMU is enabled in kernel cmdline - informational (GPU passthrough)."""
     cmdline = cmdline_path or Path("/proc/cmdline")
     if cmdline.exists():
         content = cmdline.read_text()
@@ -85,12 +85,12 @@ def _check_iommu(cmdline_path: Path | None = None) -> PreflightCheck:
     return PreflightCheck(
         name="IOMMU enabled",
         ok=True,
-        details="IOMMU not detected in kernel cmdline — only needed for GPU passthrough",
+        details="IOMMU not detected in kernel cmdline - only needed for GPU passthrough",
     )
 
 
 def _check_initcall_blacklist(cmdline_path: Path | None = None) -> PreflightCheck:
-    """Check for initcall_blacklist=sysfb_init — informational (PVE 8+ GPU passthrough)."""
+    """Check for initcall_blacklist=sysfb_init - informational (PVE 8+ GPU passthrough)."""
     cmdline = cmdline_path or Path("/proc/cmdline")
     if cmdline.exists():
         content = cmdline.read_text()
@@ -103,7 +103,7 @@ def _check_initcall_blacklist(cmdline_path: Path | None = None) -> PreflightChec
     return PreflightCheck(
         name="initcall_blacklist",
         ok=True,
-        details="initcall_blacklist not set — only needed for PVE 8+ GPU passthrough",
+        details="initcall_blacklist not set - only needed for PVE 8+ GPU passthrough",
     )
 
 
@@ -131,7 +131,7 @@ def run_preflight() -> list[PreflightCheck]:
 
     for check in checks:
         if not check.ok:
-            log.debug("Preflight fail: %s — %s", check.name, check.details)
+            log.debug("Preflight fail: %s - %s", check.name, check.details)
 
     checks.append(_check_ignore_msrs())
     checks.append(_check_iommu())
@@ -142,7 +142,7 @@ def run_preflight() -> list[PreflightCheck]:
         PreflightCheck(
             name="CPU vendor",
             ok=True,
-            details=f"{vendor} — {'Cascadelake-Server emulation' if vendor == 'AMD' else 'native host passthrough'}",
+            details=f"{vendor} - {'Cascadelake-Server emulation' if vendor == 'AMD' else 'native host passthrough'}",
         )
     )
     checks.append(

--- a/src/osx_proxmox_next/screens/step_screens.py
+++ b/src/osx_proxmox_next/screens/step_screens.py
@@ -139,14 +139,14 @@ def _compose_step4_cpu_network(cpu_info: CpuInfo) -> ComposeResult:
             value=cpu_info.needs_penryn,
         )
     yield Static(
-        "Older Intel CPU detected (pre-Skylake). Penryn mode improves macOS install stability on this hardware. (Xeon CPUs are automatically excluded — they use -cpu host.)",
+        "Older Intel CPU detected (pre-Skylake). Penryn mode improves macOS install stability on this hardware. (Xeon CPUs are automatically excluded - they use -cpu host.)",
         id="penryn_hint",
         classes="penryn_hint" + ("" if cpu_info.needs_penryn else " step_hidden"),
     )
     _e1000_default = cpu_info.is_xeon or cpu_info.needs_penryn
     with Horizontal(classes="action_row"):
         yield Checkbox(
-            "Use e1000 network adapter (recommended for Xeon / older Intel — no kext needed)",
+            "Use e1000 network adapter (recommended for Xeon / older Intel - no kext needed)",
             id="e1000_cb",
             value=_e1000_default,
         )

--- a/src/osx_proxmox_next/screens/summary_screen.py
+++ b/src/osx_proxmox_next/screens/summary_screen.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 from ..defaults import CpuInfo
 from ..domain import SUPPORTED_MACOS, PlanStep, VmConfig
+from ..planner import POST_INSTALL_BOOT_ORDER
 from ..preflight import PreflightCheck
 from ..rollback import RollbackSnapshot, rollback_hints
+from ..support import SUPPORT_LINE
 
 __all__ = [
     "build_config_summary_text",
@@ -23,7 +25,7 @@ def build_config_summary_text(
     lines = [
         f"Target: {meta.get('label', config.macos)} ({meta.get('channel', '?')})",
         f"VM: {config.vmid} / {config.name}",
-        f"CPU: {cpu_label} — {config.cores} cores | Memory: {config.memory_mb} MB | Disk: {config.disk_gb} GB",
+        f"CPU: {cpu_label} - {config.cores} cores | Memory: {config.memory_mb} MB | Disk: {config.disk_gb} GB",
         f"Storage: {config.storage} | Bridge: {config.bridge}",
     ]
     if config.installer_path:
@@ -59,11 +61,11 @@ def format_install_result(
             "Install completed successfully!",
             f"Log: {log_path}",
             "",
-            "POST-INSTALL: After macOS finishes installing, fix the boot order",
-            "so the main disk boots first (instead of recovery):",
-            f"  qm set {vmid} --boot order=virtio0;ide0",
+            "POST-INSTALL: After macOS finishes installing, run:",
+            f"  osx-next-cli post-install --vmid {vmid} --execute",
+            f"This switches boot order to {POST_INSTALL_BOOT_ORDER} (OpenCore first).",
             "",
-            "If this saved you time: https://ko-fi.com/lucidfabrics",
+            SUPPORT_LINE,
         ]
     else:
         lines = ["Install FAILED.", f"Log: {log_path}"]

--- a/src/osx_proxmox_next/support.py
+++ b/src/osx_proxmox_next/support.py
@@ -1,0 +1,10 @@
+"""Donation/support messaging shared by CLI and TUI so copy never drifts."""
+
+KOFI_URL = "https://ko-fi.com/lucidfabrics"
+
+SUPPORT_LINE = f"If this saved you time: {KOFI_URL}"
+
+SUPPORT_LINES_POST_INSTALL = (
+    "Manual OpenCore setup takes hours. This took minutes.",
+    f"If that is worth a coffee: {KOFI_URL}",
+)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -255,7 +255,7 @@ def test_cli_apply_success(monkeypatch, tmp_path):
     assert rc == 0
 
 
-def test_cli_apply_failure(monkeypatch, tmp_path):
+def test_cli_apply_failure(monkeypatch, tmp_path, capsys):
     from osx_proxmox_next.assets import AssetCheck
     from osx_proxmox_next.executor import ApplyResult
     from osx_proxmox_next.rollback import RollbackSnapshot
@@ -284,6 +284,7 @@ def test_cli_apply_failure(monkeypatch, tmp_path):
         "--storage", "local-lvm",
     ])
     assert rc == 4
+    assert "ko-fi" not in capsys.readouterr().out
 
 
 def test_config_from_args_smbios():
@@ -739,7 +740,7 @@ def test_cli_uninstall_vm_not_found(monkeypatch):
     assert rc == 2
 
 
-def test_cli_uninstall_execute_success(monkeypatch, tmp_path):
+def test_cli_uninstall_execute_success(monkeypatch, tmp_path, capsys):
     from osx_proxmox_next.executor import ApplyResult
     from osx_proxmox_next.planner import VmInfo
     from osx_proxmox_next.rollback import RollbackSnapshot
@@ -758,6 +759,7 @@ def test_cli_uninstall_execute_success(monkeypatch, tmp_path):
     )
     rc = run_cli(["uninstall", "--vmid", "106", "--execute"])
     assert rc == 0
+    assert "ko-fi" not in capsys.readouterr().out
 
 
 def test_cli_uninstall_execute_failure(monkeypatch, tmp_path):
@@ -1037,7 +1039,7 @@ def test_cli_clone_execute_success(monkeypatch, tmp_path, capsys) -> None:
     assert "901" in out
 
 
-def test_cli_clone_execute_failure(monkeypatch, tmp_path) -> None:
+def test_cli_clone_execute_failure(monkeypatch, tmp_path, capsys) -> None:
     from osx_proxmox_next.executor import ApplyResult
     from osx_proxmox_next.planner import VmInfo
 
@@ -1051,6 +1053,7 @@ def test_cli_clone_execute_failure(monkeypatch, tmp_path) -> None:
     )
     rc = run_cli(["clone", "--source-vmid", "900", "--new-vmid", "901", "--execute"])
     assert rc == 8
+    assert "ko-fi" not in capsys.readouterr().out
 
 
 def test_cli_clone_preserves_bridge_from_source(monkeypatch, tmp_path, capsys) -> None:
@@ -1106,7 +1109,9 @@ def test_cli_doctor_all_ok(monkeypatch, capsys) -> None:
     monkeypatch.setattr(cli_module, "run_doctor", lambda vmid: _make_doctor_checks())
     rc = run_cli(["doctor", "--vmid", "100"])
     assert rc == 0
-    assert "All checks passed" in capsys.readouterr().out
+    out = capsys.readouterr().out
+    assert "All checks passed" in out
+    assert "ko-fi" not in out
 
 
 def test_cli_doctor_with_failures(monkeypatch, capsys) -> None:
@@ -1154,6 +1159,7 @@ def test_cli_clone_execute_success_prints_apple_services(monkeypatch, tmp_path, 
     assert rc == 0
     out = capsys.readouterr().out
     assert "Apple services" in out
+    assert "ko-fi.com/lucidfabrics" in out
 
 
 def test_cli_clone_execute_no_apple_services_no_message(monkeypatch, tmp_path, capsys) -> None:
@@ -1210,6 +1216,7 @@ def test_cli_post_install_execute_success(monkeypatch, tmp_path, capsys) -> None
     out = capsys.readouterr().out
     assert "Post-install OK" in out
     assert POST_INSTALL_BOOT_ORDER in out
+    assert "ko-fi.com/lucidfabrics" in out
 
 
 def test_cli_post_install_execute_failure(monkeypatch, tmp_path, capsys) -> None:
@@ -1220,7 +1227,9 @@ def test_cli_post_install_execute_failure(monkeypatch, tmp_path, capsys) -> None
     )
     rc = run_cli(["post-install", "--vmid", "102", "--execute"])
     assert rc == 9
-    assert "FAILED" in capsys.readouterr().out
+    out = capsys.readouterr().out
+    assert "FAILED" in out
+    assert "ko-fi" not in out
 
 
 def test_cli_apply_post_install_hint_correct(monkeypatch, tmp_path, capsys) -> None:
@@ -1249,3 +1258,5 @@ def test_cli_apply_post_install_hint_correct(monkeypatch, tmp_path, capsys) -> N
     assert "post-install" in out
     assert POST_INSTALL_BOOT_ORDER in out
     assert "virtio0;ide0" not in out
+    assert "ko-fi.com/lucidfabrics" in out
+    assert "buymeacoffee" not in out

--- a/tests/test_screens.py
+++ b/tests/test_screens.py
@@ -122,3 +122,24 @@ class TestStepScreensImport:
         cpu = _cpu()
         result = compose_step4(cpu)
         assert isinstance(result, types.GeneratorType)
+
+
+class TestFormatInstallResult:
+    def test_success_references_post_install_subcommand(self):
+        from osx_proxmox_next.planner import POST_INSTALL_BOOT_ORDER
+        from osx_proxmox_next.screens.summary_screen import format_install_result
+        text = format_install_result(ok=True, vmid=900, log_path="/tmp/log.txt", snapshot=None)
+        assert "Install completed successfully!" in text
+        assert "osx-next-cli post-install --vmid 900" in text
+        assert POST_INSTALL_BOOT_ORDER in text
+        assert "virtio0;ide0" not in text
+        assert "ko-fi.com/lucidfabrics" in text
+
+    def test_failure_shows_rollback_hints_and_no_donation_ask(self):
+        from osx_proxmox_next.rollback import RollbackSnapshot
+        from osx_proxmox_next.screens.summary_screen import format_install_result
+        from pathlib import Path
+        snap = RollbackSnapshot(vmid=900, path=Path("/tmp/snap.conf"))
+        text = format_install_result(ok=False, vmid=900, log_path="/tmp/log.txt", snapshot=snap)
+        assert "Install FAILED." in text
+        assert "ko-fi" not in text


### PR DESCRIPTION
## Summary

Places donation asks exactly where user motivation peaks and nowhere else. Adds the missing ask at the highest-gratitude moment in the product: post-install success, when the macOS VM finally boots. Also fixes the stale TUI boot-order hint left behind by #79.

Closes #80

## Changes

- New `support.py` with shared constants (`KOFI_URL`, `SUPPORT_LINE`, `SUPPORT_LINES_POST_INSTALL`) so CLI and TUI copy never drift
- `post-install` success: primary ask with reciprocity framing ("Manual OpenCore setup takes hours. This took minutes.")
- `clone` success: short single-link ask
- `apply` success: simplified from two links to one (ko-fi only; BMC stays in README)
- TUI install summary: replaced wrong `virtio0;ide0` hint with the `post-install` subcommand and correct `ide0;virtio0` order, donation line now uses the shared constant
- No asks on failures, dry runs, doctor, edit, download, or uninstall (success-only, no dilution)
- Em dash sweep across user-facing strings (cli, doctor, preflight, assets, step_screens, summary_screen)

## Tests

- New: 2 `format_install_result` unit tests (regression lock on the boot-order fix, no ask on failure)
- Updated: ko-fi assertions on apply/clone/post-install success, no-ask guards on apply/clone/post-install failure and doctor/uninstall success, `buymeacoffee` absence locked in

## Pre-Flight Results

| Check | Result |
|-------|--------|
| Tests | PASS (841 passed) |
| Coverage | PASS (>=95%) |
| buymeacoffee in src | CLEAN (egg-info build artifact only) |
| Em dash in user-facing strings | CLEAN |

## Testing

- [ ] Run `apply` to success on a PVE node, verify single ko-fi line
- [ ] Run `post-install --execute`, verify two-line reciprocity ask
- [ ] TUI install, verify summary shows post-install subcommand and correct boot order
