### PR TITLE
feat(support): add ASCII coffee cup art to donation asks

### DIFF
--- a/src/osx_proxmox_next/support.py
+++ b/src/osx_proxmox_next/support.py
@@ -2,9 +2,14 @@
 
 KOFI_URL = "https://ko-fi.com/lucidfabrics"
 
-SUPPORT_LINE = f"If this saved you time: {KOFI_URL}"
+SUPPORT_LINE = f"c[_] If this saved you time: {KOFI_URL}"
 
 SUPPORT_LINES_POST_INSTALL = (
-    "Manual OpenCore setup takes hours. This took minutes.",
-    f"If that is worth a coffee: {KOFI_URL}",
+    r"     ) )",
+    r"    ( (",
+    r"  ._______.",
+    r"  |       |)   Manual OpenCore setup takes hours.",
+    r"  |       |    This took minutes.",
+    r"   \_____/     Worth a coffee?",
+    f"               {KOFI_URL}",
 )


### PR DESCRIPTION
## Summary

Adds ASCII art to the donation asks. Post-install success (the peak moment) gets a steaming coffee cup next to the reciprocity message; the short asks (apply, clone, TUI summary) get a tiny inline mug. All copy lives in `support.py`, so this is a single-file change.

## Preview

Post-install success:

```
     ) )
    ( (
  ._______.
  |       |)   Manual OpenCore setup takes hours.
  |       |    This took minutes.
   \_____/     Worth a coffee?
               https://ko-fi.com/lucidfabrics
```

Apply / clone / TUI:

```
c[_] If this saved you time: https://ko-fi.com/lucidfabrics
```

## Pre-Flight Results

| Check | Result |
|-------|--------|
| Tests | PASS (841 passed) |
| Coverage | PASS (>=95%) |

## Testing

- [ ] Run post-install --execute on a PVE node, verify cup renders in terminal
- [ ] TUI install, verify inline mug renders in result box
