### PR TITLE
feat(opencore): ship RestrictEvents to silence MacPro7,1 memory warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -663,13 +663,19 @@ For GPU passthrough on a current macOS guest (Ventura, Sonoma, Sequoia, Tahoe), 
 
 This is cosmetic and specific to the `MacPro7,1` SMBIOS. macOS knows the real Mac Pro has 12 RAM slots and expects them filled in groups, so a VM's flat memory layout trips the warning. Nothing is actually wrong with the VM.
 
-To silence it, add `RestrictEvents.kext` to `EFI/OC/Kexts/` and set the boot-arg `revpatch=memtab`. If you change the boot-arg and it has no effect, set it directly from macOS, because OpenCore only writes a value when one is not already present:
+**VMs created from v0.26 onward are fixed automatically.** The OpenCore disk build now injects [RestrictEvents.kext](https://github.com/acidanthera/RestrictEvents), whose default `revblock=auto` setting blocks the `MemorySlotNotification` and `ExpansionSlotNotification` processes that produce the warning. No boot-arg is required.
 
-```bash
-sudo nvram boot-args="revpatch=memtab"
-```
+> Earlier versions of this FAQ suggested `revpatch=memtab`. That value only enables the Memory tab on MacBookAir SMBIOS models and does nothing on `MacPro7,1`, so skip it. The process blocking that removes the warning is on by default once the kext is present.
 
-Reboot afterward. Avoid changing the SMBIOS model to dodge the warning if you already have iCloud/iMessage working, since those are bound to the `MacPro7,1` identity.
+For a VM created before v0.26, fix it in place:
+
+1. Shut down the VM and back it up.
+2. Mount partition 1 of the OpenCore disk (the small `ide0` disk) on the Proxmox host.
+3. Download the [RestrictEvents release zip](https://github.com/acidanthera/RestrictEvents/releases) and copy `RestrictEvents.kext` into `EFI/OC/Kexts/`.
+4. Add a `Kernel > Add` entry in `config.plist` with `BundlePath` `RestrictEvents.kext`, `ExecutablePath` `Contents/MacOS/RestrictEvents`, `PlistPath` `Contents/Info.plist`, `Enabled` `True`. Keep `Lilu.kext` above it in the list.
+5. Unmount, boot, then dismiss any old copy of the warning still sitting in Notification Center. Blocking stops new notifications but does not clear ones already delivered.
+
+Avoid changing the SMBIOS model to dodge the warning if you already have iCloud/iMessage working, since those are bound to the `MacPro7,1` identity.
 
 ### My desktop wallpaper is white or blank
 

--- a/scripts/bash/osx-proxmox-next.sh
+++ b/scripts/bash/osx-proxmox-next.sh
@@ -660,6 +660,22 @@ function build_opencore_disk() {
     exit 1
   fi
 
+  # Add RestrictEvents.kext (silences MacPro7,1 "Memory Modules Misconfigured")
+  local re_zip
+  re_zip="$(dirname "$source_iso")/RestrictEvents-1.1.6-RELEASE.zip"
+  if [ ! -f "$re_zip" ]; then
+    curl -fsSL -o "$re_zip" "https://github.com/acidanthera/RestrictEvents/releases/download/1.1.6/RestrictEvents-1.1.6-RELEASE.zip" \
+      || echo -e "  ${YW}WARN: RestrictEvents download failed, memory warning fix skipped${CL}"
+  fi
+  if [ -f "$re_zip" ]; then
+    RE_ZIP="$re_zip" OC_KEXTS="$dest_mnt/EFI/OC/Kexts" python3 -c '
+import os, zipfile
+z = zipfile.ZipFile(os.environ["RE_ZIP"])
+names = [n for n in z.namelist() if n.startswith("RestrictEvents.kext/")]
+z.extractall(os.environ["OC_KEXTS"], members=names)
+' || echo -e "  ${YW}WARN: RestrictEvents extraction failed, memory warning fix skipped${CL}"
+  fi
+
   # Patch config.plist for VM compatibility
   if [ -f "$dest_mnt/EFI/OC/config.plist" ]; then
     python3 -c "
@@ -695,6 +711,17 @@ nv_del['7C436110-AB2A-4BBB-A880-FE41995C9F82'] = ['csr-active-config', 'boot-arg
 pl['NVRAM']['WriteFlash'] = True
 # Enable VirtualSMC
 [k.update(Enabled=True) for k in pl.get('Kernel', {}).get('Add', []) if 'VirtualSMC' in k.get('BundlePath', '')]
+# Register RestrictEvents.kext if present (default revblock=auto blocks the
+# MacPro7,1 memory misconfiguration notifier; no boot-arg needed)
+import os
+ka = pl.setdefault('Kernel', {}).setdefault('Add', [])
+kx = os.path.join(os.path.dirname(path), 'Kexts', 'RestrictEvents.kext')
+if os.path.isdir(kx) and 'RestrictEvents.kext' not in [k.get('BundlePath') for k in ka]:
+    ka.append({'Arch': 'Any', 'BundlePath': 'RestrictEvents.kext',
+               'Comment': 'Silence MacPro7,1 memory warning', 'Enabled': True,
+               'ExecutablePath': 'Contents/MacOS/RestrictEvents',
+               'MaxKernel': '', 'MinKernel': '', 'PlistPath': 'Contents/Info.plist'})
+[k.update(Enabled=True) for k in ka if 'RestrictEvents' in k.get('BundlePath', '')]
 # AMD-specific patches
 if cpu_vendor == 'AMD':
     kq = pl['Kernel']['Quirks']

--- a/src/osx_proxmox_next/cli.py
+++ b/src/osx_proxmox_next/cli.py
@@ -12,7 +12,14 @@ from .defaults import DEFAULT_ISO_DIR, detect_cpu_info, detect_iso_storage, dete
 from .diagnostics import export_log_bundle, recovery_guide
 from .doctor import run_doctor, Severity
 from .domain import MIN_VMID, MAX_VMID, SUPPORTED_MACOS, VmConfig, EditChanges, validate_config, validate_edit_changes
-from .downloader import DownloadError, DownloadProgress, download_opencore, download_recovery
+from .downloader import (
+    DownloadError,
+    DownloadProgress,
+    download_opencore,
+    download_recovery,
+    download_restrictevents,
+    ensure_restrictevents,
+)
 from .executor import apply_plan
 from .planner import build_plan, build_destroy_plan, build_edit_plan, build_clone_plan, build_post_install_plan, POST_INSTALL_BOOT_ORDER
 from .services import fetch_vm_info, get_proxmox_adapter, run_download_worker
@@ -64,6 +71,9 @@ def _auto_download_missing(config: VmConfig, dest_dir: Path) -> None:
     assets = required_assets(config)
     missing = [a for a in assets if not a.ok and a.downloadable]
     if not missing:
+        # ISO may be cached from an older version; still make sure the
+        # RestrictEvents kext zip is available for the OpenCore disk build.
+        ensure_restrictevents(dest_dir)
         return
 
     config_with_dir = config if config.iso_dir else \
@@ -447,6 +457,12 @@ def _run_download(args: argparse.Namespace) -> int:
         except DownloadError as exc:
             print(f"\nOpenCore download failed: {exc}")
             ok = False
+        try:
+            path = download_restrictevents(dest_dir, on_progress=_cli_progress,
+                                           force=getattr(args, "force", False))
+            print(f"\nDownloaded: {path}")
+        except DownloadError as exc:
+            print(f"\nRestrictEvents download failed (memory warning fix skipped): {exc}")
 
     if not args.opencore_only:
         print(f"Downloading recovery image for {macos}...")

--- a/src/osx_proxmox_next/downloader.py
+++ b/src/osx_proxmox_next/downloader.py
@@ -57,6 +57,40 @@ _BACKOFF_SECONDS = [1, 2, 4]
 _OPENCORE_UNIVERSAL = "opencore-osx-proxmox-vm.iso"
 _ASSETS_TAG = "assets"
 
+# RestrictEvents silences the cosmetic "Memory Modules Misconfigured"
+# notification that macOS shows on every boot with the MacPro7,1 SMBIOS
+# (the real Mac Pro has 12 RAM slots; a VM's flat layout trips the check).
+# Its default revblock=auto blocks the MemorySlotNotification and
+# ExpansionSlotNotification processes, so no boot-arg is needed.
+RESTRICTEVENTS_VERSION = "1.1.6"
+RESTRICTEVENTS_ZIP = f"RestrictEvents-{RESTRICTEVENTS_VERSION}-RELEASE.zip"
+RESTRICTEVENTS_URL = (
+    "https://github.com/acidanthera/RestrictEvents/releases/download/"
+    f"{RESTRICTEVENTS_VERSION}/{RESTRICTEVENTS_ZIP}"
+)
+
+
+def download_restrictevents(
+    dest_dir: Path,
+    on_progress: ProgressCallback = None,
+    force: bool = False,
+) -> Path:
+    dest = dest_dir / RESTRICTEVENTS_ZIP
+    if dest.exists() and not force:
+        log.debug("RestrictEvents cache hit: %s", dest)
+        return dest
+    _download_file(RESTRICTEVENTS_URL, dest, on_progress, "restrictevents")
+    return dest
+
+
+def ensure_restrictevents(dest_dir: Path) -> Optional[Path]:
+    """Best-effort RestrictEvents fetch; the fix is cosmetic so failure is non-fatal."""
+    try:
+        return download_restrictevents(dest_dir)
+    except DownloadError as exc:
+        log.warning("RestrictEvents download failed, memory warning fix skipped: %s", exc)
+        return None
+
 
 def download_opencore(
     macos: str,

--- a/src/osx_proxmox_next/script_renderer.py
+++ b/src/osx_proxmox_next/script_renderer.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from shlex import quote as shquote
 
 from .domain import SUPPORTED_MACOS, VmConfig
+from .downloader import RESTRICTEVENTS_URL, RESTRICTEVENTS_ZIP
 from .smbios_planner import _sanitize_smbios
 
 log = logging.getLogger(__name__)
@@ -160,11 +161,43 @@ def _plist_patch_script(
         "p[\"NVRAM\"][\"WriteFlash\"]=True; "
         "p.setdefault(\"UEFI\",{}).setdefault(\"Quirks\",{})[\"RequestBootVarRouting\"]=True; "
         "[k.update(Enabled=True) for k in p.get(\"Kernel\",{}).get(\"Add\",[]) if \"VirtualSMC\" in k.get(\"BundlePath\",\"\")]; "
+        "ka=p.setdefault(\"Kernel\",{}).setdefault(\"Add\",[]); "
+        "os.path.isdir(oc_dest+\"/EFI/OC/Kexts/RestrictEvents.kext\") "
+        "and (\"RestrictEvents.kext\" not in [k.get(\"BundlePath\") for k in ka]) "
+        "and ka.append({\"Arch\":\"Any\",\"BundlePath\":\"RestrictEvents.kext\","
+        "\"Comment\":\"Silence MacPro7,1 memory warning\",\"Enabled\":True,"
+        "\"ExecutablePath\":\"Contents/MacOS/RestrictEvents\",\"MaxKernel\":\"\","
+        "\"MinKernel\":\"\",\"PlistPath\":\"Contents/Info.plist\"}); "
+        "[k.update(Enabled=True) for k in ka if \"RestrictEvents\" in k.get(\"BundlePath\",\"\")]; "
         + amd_patch
         + platforminfo
         + apple_id_bypass
         + "f=open(oc_dest+\"/EFI/OC/config.plist\",\"wb\"); plistlib.dump(p,f); f.close(); "
         "import sys; sys.stderr.write(\"config.plist patched\\n\")'"
+    )
+
+
+def _inject_restrictevents_script(opencore_path: Path) -> str:
+    """Return bash snippet that adds RestrictEvents.kext to the EFI being built.
+
+    The kext zip is normally pre-downloaded next to the OpenCore ISO. If it is
+    missing (cached ISO, download phase skipped), curl it directly; if that
+    also fails the build continues, since the fix is purely cosmetic.
+    """
+    zip_path = opencore_path.parent / RESTRICTEVENTS_ZIP
+    return (
+        f"export RE_ZIP={shquote(str(zip_path))}; "
+        f"[ -f \"$RE_ZIP\" ] || curl -fsSL -o \"$RE_ZIP\" {shquote(RESTRICTEVENTS_URL)} "
+        "|| echo 'WARN: RestrictEvents download failed'; "
+        "if [ -f \"$RE_ZIP\" ]; then "
+        "python3 -c '"
+        "import os, zipfile; "
+        "z=zipfile.ZipFile(os.environ[\"RE_ZIP\"]); "
+        "names=[n for n in z.namelist() if n.startswith(\"RestrictEvents.kext/\")]; "
+        "z.extractall(os.environ[\"OC_DEST\"]+\"/EFI/OC/Kexts\", members=names); "
+        "import sys; sys.stderr.write(\"RestrictEvents.kext injected\\n\")' "
+        "|| echo 'WARN: RestrictEvents.kext extraction failed, memory warning fix skipped'; "
+        "else echo 'WARN: RestrictEvents.kext unavailable, memory warning fix skipped'; fi && "
     )
 
 
@@ -238,6 +271,8 @@ def _build_oc_disk_script(
         + "cp -a $OC_SRC/. $OC_DEST/ && "
         # Validate EFI structure was copied
         "{ [ -d $OC_DEST/EFI/OC ] || { echo 'ERROR: OpenCore ISO does not contain expected EFI/OC directory. ISO may be corrupt.'; false; }; } && "
+        # Add RestrictEvents.kext (silences MacPro7,1 memory warning)
+        + _inject_restrictevents_script(opencore_path)
         # Patch config.plist
         + plist_script + " && "
         # Fix plistlib self-closing tags that OpenCore's OcXmlLib rejects

--- a/src/osx_proxmox_next/services/download_service.py
+++ b/src/osx_proxmox_next/services/download_service.py
@@ -7,7 +7,13 @@ from pathlib import Path
 from ..assets import AssetCheck, required_assets
 from ..defaults import DEFAULT_ISO_DIR
 from ..domain import VmConfig
-from ..downloader import DownloadError, DownloadProgress, download_opencore, download_recovery
+from ..downloader import (
+    DownloadError,
+    DownloadProgress,
+    download_opencore,
+    download_recovery,
+    ensure_restrictevents,
+)
 
 log = logging.getLogger(__name__)
 
@@ -29,6 +35,11 @@ def run_download_worker(
     """
     dest_dir = Path(config.iso_dir or DEFAULT_ISO_DIR)
     errors: list[str] = []
+
+    # Always cache the RestrictEvents kext zip alongside the ISO so the
+    # OpenCore disk build can inject it (silences the MacPro7,1 memory
+    # warning). Best-effort: the build script falls back to curl if absent.
+    ensure_restrictevents(dest_dir)
 
     def _progress_cb(p: DownloadProgress) -> None:
         if p.total > 0:

--- a/tests/test_app_wizard.py
+++ b/tests/test_app_wizard.py
@@ -18,6 +18,14 @@ from osx_proxmox_next.services import install_service
 from osx_proxmox_next.services import destroy_service
 from osx_proxmox_next.services import preflight_service
 
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _stub_restrictevents(monkeypatch):
+    """Keep the best-effort RestrictEvents fetch off the network in tests."""
+    monkeypatch.setattr(download_service, "ensure_restrictevents", lambda dest_dir: None)
+
 
 class FakePve:
     """Test helper that mimics ProxmoxAdapter with canned responses."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,30 @@
 import subprocess
 from pathlib import Path
 
+import pytest
+
 from osx_proxmox_next import cli as cli_module
 from osx_proxmox_next.cli import run_cli
 from osx_proxmox_next.planner import POST_INSTALL_BOOT_ORDER
+
+
+@pytest.fixture(autouse=True)
+def _stub_restrictevents(monkeypatch, tmp_path):
+    """Keep the best-effort RestrictEvents fetch off the network in tests."""
+    ensured: list[Path] = []
+    downloaded: list[bool] = []
+
+    monkeypatch.setattr(
+        cli_module, "ensure_restrictevents",
+        lambda dest_dir: ensured.append(dest_dir) or None,
+    )
+
+    def fake_download(dest_dir, on_progress=None, force=False):
+        downloaded.append(force)
+        return tmp_path / "RestrictEvents-1.1.6-RELEASE.zip"
+
+    monkeypatch.setattr(cli_module, "download_restrictevents", fake_download)
+    return {"ensured": ensured, "downloaded": downloaded}
 
 
 def test_cli_parser_has_expected_commands() -> None:
@@ -406,6 +427,70 @@ def test_download_force_passes_through(monkeypatch, tmp_path):
                   "--opencore-only", "--force"])
     assert rc == 0
     assert captured["force"] is True
+
+
+def test_auto_download_missing_cached_assets_still_ensures_restrictevents(
+    monkeypatch, tmp_path, _stub_restrictevents
+):
+    """A fully cached asset set must still pull the RestrictEvents kext zip."""
+    from osx_proxmox_next.cli import _auto_download_missing
+    from osx_proxmox_next.assets import AssetCheck
+
+    monkeypatch.setattr(
+        cli_module, "required_assets",
+        lambda cfg: [AssetCheck("OpenCore image", Path("/tmp/oc.iso"), True, "")],
+    )
+
+    from osx_proxmox_next.domain import VmConfig
+    cfg = VmConfig(vmid=900, name="macos-sequoia", macos="sequoia", cores=8,
+                   memory_mb=16384, disk_gb=128, bridge="vmbr0", storage="local-lvm")
+    _auto_download_missing(cfg, tmp_path)
+    assert _stub_restrictevents["ensured"] == [tmp_path]
+
+
+def test_download_fetches_restrictevents(monkeypatch, tmp_path, _stub_restrictevents):
+    """`download` pulls the RestrictEvents kext zip alongside OpenCore."""
+    monkeypatch.setattr(
+        cli_module, "download_opencore",
+        lambda macos, dest_dir, on_progress=None, force=False: tmp_path / "oc.iso",
+    )
+    rc = run_cli(["download", "--macos", "sequoia", "--dest", str(tmp_path),
+                  "--opencore-only"])
+    assert rc == 0
+    assert _stub_restrictevents["downloaded"] == [False]
+
+
+def test_download_force_passes_through_to_restrictevents(
+    monkeypatch, tmp_path, _stub_restrictevents
+):
+    monkeypatch.setattr(
+        cli_module, "download_opencore",
+        lambda macos, dest_dir, on_progress=None, force=False: tmp_path / "oc.iso",
+    )
+    rc = run_cli(["download", "--macos", "sequoia", "--dest", str(tmp_path),
+                  "--opencore-only", "--force"])
+    assert rc == 0
+    assert _stub_restrictevents["downloaded"] == [True]
+
+
+def test_download_restrictevents_failure_is_non_fatal(monkeypatch, tmp_path, capsys):
+    """A RestrictEvents download error must not fail the download command."""
+    from osx_proxmox_next.downloader import DownloadError
+
+    monkeypatch.setattr(
+        cli_module, "download_opencore",
+        lambda macos, dest_dir, on_progress=None, force=False: tmp_path / "oc.iso",
+    )
+
+    def boom(dest_dir, on_progress=None, force=False):
+        raise DownloadError("offline")
+
+    monkeypatch.setattr(cli_module, "download_restrictevents", boom)
+    rc = run_cli(["download", "--macos", "sequoia", "--dest", str(tmp_path),
+                  "--opencore-only"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "memory warning fix skipped" in out
 
 
 def test_download_without_force_defaults_false(monkeypatch, tmp_path):

--- a/tests/test_download_service.py
+++ b/tests/test_download_service.py
@@ -39,6 +39,17 @@ def _noop_progress(phase: str, pct: int) -> None:
     pass
 
 
+@pytest.fixture(autouse=True)
+def _stub_restrictevents(monkeypatch):
+    """Keep the best-effort RestrictEvents fetch off the network in tests."""
+    calls: list[Path] = []
+    monkeypatch.setattr(
+        "osx_proxmox_next.services.download_service.ensure_restrictevents",
+        lambda dest_dir: calls.append(dest_dir) or None,
+    )
+    return calls
+
+
 # ---------------------------------------------------------------------------
 # Happy path — downloads succeed
 # ---------------------------------------------------------------------------
@@ -47,6 +58,11 @@ def _noop_progress(phase: str, pct: int) -> None:
 def test_run_download_worker_empty_missing_returns_no_errors(monkeypatch) -> None:
     errors = run_download_worker(_make_config(), [], _noop_progress)
     assert errors == []
+
+
+def test_run_download_worker_always_fetches_restrictevents(_stub_restrictevents) -> None:
+    run_download_worker(_make_config(), [], _noop_progress)
+    assert _stub_restrictevents == [Path("/tmp/iso")]
 
 
 def test_run_download_worker_opencore_calls_download_opencore(monkeypatch) -> None:

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -797,3 +797,64 @@ class TestRecoveryOsType:
 
         download_recovery("tahoe", tmp_path)
         assert captured[0] == "latest"
+
+
+class TestDownloadRestrictEvents:
+    def test_cache_hit_skips_download(self, tmp_path, monkeypatch):
+        from osx_proxmox_next.downloader import RESTRICTEVENTS_ZIP, download_restrictevents
+
+        cached = tmp_path / RESTRICTEVENTS_ZIP
+        cached.write_bytes(b"zip")
+        called = []
+        monkeypatch.setattr(dl_module, "_download_file",
+                            lambda *a, **k: called.append(a))
+
+        result = download_restrictevents(tmp_path)
+        assert result == cached
+        assert called == []
+
+    def test_downloads_when_missing(self, tmp_path, monkeypatch):
+        from osx_proxmox_next.downloader import (
+            RESTRICTEVENTS_URL, RESTRICTEVENTS_ZIP, download_restrictevents,
+        )
+
+        calls = []
+
+        def fake_download(url, dest, on_progress, phase):
+            calls.append((url, dest, phase))
+            dest.write_bytes(b"zip")
+
+        monkeypatch.setattr(dl_module, "_download_file", fake_download)
+        result = download_restrictevents(tmp_path)
+        assert result == tmp_path / RESTRICTEVENTS_ZIP
+        assert calls == [(RESTRICTEVENTS_URL, tmp_path / RESTRICTEVENTS_ZIP, "restrictevents")]
+
+    def test_force_redownloads_cached_zip(self, tmp_path, monkeypatch):
+        from osx_proxmox_next.downloader import RESTRICTEVENTS_ZIP, download_restrictevents
+
+        cached = tmp_path / RESTRICTEVENTS_ZIP
+        cached.write_bytes(b"old")
+        calls = []
+        monkeypatch.setattr(dl_module, "_download_file",
+                            lambda url, dest, on_progress, phase: calls.append(url))
+
+        download_restrictevents(tmp_path, force=True)
+        assert len(calls) == 1
+
+
+class TestEnsureRestrictEvents:
+    def test_returns_path_on_success(self, tmp_path, monkeypatch):
+        from osx_proxmox_next.downloader import RESTRICTEVENTS_ZIP, ensure_restrictevents
+
+        cached = tmp_path / RESTRICTEVENTS_ZIP
+        cached.write_bytes(b"zip")
+        assert ensure_restrictevents(tmp_path) == cached
+
+    def test_swallows_download_error(self, tmp_path, monkeypatch):
+        from osx_proxmox_next.downloader import ensure_restrictevents
+
+        def boom(url, dest, on_progress, phase):
+            raise DownloadError("offline")
+
+        monkeypatch.setattr(dl_module, "_download_file", boom)
+        assert ensure_restrictevents(tmp_path) is None

--- a/tests/test_script_renderer.py
+++ b/tests/test_script_renderer.py
@@ -254,3 +254,56 @@ def test_build_oc_disk_script_contains_dest_path() -> None:
         macos="sequoia",
     )
     assert str(dest) in result
+
+
+# ---------------------------------------------------------------------------
+# RestrictEvents injection (silences MacPro7,1 "Memory Modules Misconfigured")
+# ---------------------------------------------------------------------------
+
+
+def _oc_script() -> str:
+    return _build_oc_disk_script(
+        opencore_path=Path("/iso/opencore.iso"),
+        recovery_path=Path("/iso/sequoia-recovery.iso"),
+        dest=Path("/tmp/oc.img"),
+        macos="sequoia",
+    )
+
+
+def test_build_oc_disk_script_injects_restrictevents() -> None:
+    result = _oc_script()
+    assert "RestrictEvents.kext" in result
+    assert "RestrictEvents-1.1.6-RELEASE.zip" in result
+
+
+def test_build_oc_disk_script_restrictevents_zip_next_to_iso() -> None:
+    result = _oc_script()
+    assert "/iso/RestrictEvents-1.1.6-RELEASE.zip" in result
+
+
+def test_build_oc_disk_script_restrictevents_curl_fallback() -> None:
+    result = _oc_script()
+    assert "curl -fsSL" in result
+    assert "github.com/acidanthera/RestrictEvents/releases/download" in result
+
+
+def test_build_oc_disk_script_restrictevents_failure_is_non_fatal() -> None:
+    result = _oc_script()
+    assert "memory warning fix skipped" in result
+
+
+def test_build_oc_disk_script_injection_runs_before_plist_patch() -> None:
+    result = _oc_script()
+    assert result.index("RE_ZIP") < result.index("plistlib")
+
+
+def test_plist_patch_script_registers_restrictevents_kext() -> None:
+    script = _plist_patch_script()
+    assert "RestrictEvents.kext" in script
+    assert "Contents/MacOS/RestrictEvents" in script
+    assert "Contents/Info.plist" in script
+
+
+def test_plist_patch_script_restrictevents_entry_guarded_by_kext_dir() -> None:
+    script = _plist_patch_script()
+    assert 'os.path.isdir(oc_dest+"/EFI/OC/Kexts/RestrictEvents.kext")' in script


### PR DESCRIPTION
## Summary
Fixes the Memory Modules Misconfigured notification reported on Discord (Sequoia and Sonoma VMs). Every VM uses the MacPro7,1 SMBIOS, but the OpenCore image ships no RestrictEvents.kext, so macOS warns about the flat RAM layout on every boot.

## Root cause
- The OpenCore ISO asset contains 14 kexts but not RestrictEvents.
- The FAQ shipped in 0.22.0 recommends `revpatch=memtab`, which only enables the Memory tab on MacBookAir/MacBookPro10,x SMBIOS models. It does nothing on MacPro7,1, which is why the workaround failed for the reporter.
- The correct mechanism is RestrictEvents' process blocking (`revblock`), which defaults to `auto` and blocks MemorySlotNotification and ExpansionSlotNotification on MacPro7,1. No boot-arg needed, the kext just has to be present and enabled.

## Changes
- OpenCore disk build extracts RestrictEvents.kext (1.1.6, pinned) into EFI/OC/Kexts and registers it in config.plist Kernel > Add (idempotent, kept after Lilu).
- Download phase caches the kext zip next to the ISO; build script falls back to curl, and skips with a warning when offline (fix is cosmetic, never fails the build).
- `download --force` re-fetches the zip as well.
- FAQ rewritten: removes the wrong `revpatch=memtab` advice, documents the in-place fix for existing VMs, and notes that an already-delivered notification must be dismissed once in Notification Center.

## Testing
- [x] 858 tests pass, coverage 98% (gate 95%)
- [x] Injection + plist patch executed against the real `opencore-osx-proxmox-vm.iso` config.plist: kext extracted, entry appended after Lilu, second run adds no duplicate
- [ ] Needs a tester boot on a real Proxmox host (Discord reporter)