### PR TITLE
fix: validate storage before apply, fix recovery partprobe ordering (#84)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,9 +10,9 @@ body:
   - type: input
     id: version
     attributes:
-      label: osx-proxmox version
-      description: Run `osx-proxmox --version`
-      placeholder: "0.6.0"
+      label: osx-proxmox-next version
+      description: Run `osx-proxmox-next --version`
+      placeholder: "0.25.0"
     validations:
       required: true
   - type: input
@@ -28,6 +28,7 @@ body:
     attributes:
       label: macOS version
       options:
+        - Ventura 13
         - Sonoma 14
         - Sequoia 15
         - Tahoe 26

--- a/src/osx_proxmox_next/app.py
+++ b/src/osx_proxmox_next/app.py
@@ -295,8 +295,10 @@ class NextApp(WizardStepsMixin, ManageModeMixin, EditModeMixin, App):
         if not self.state.config:
             return
         label = SUPPORTED_MACOS.get(self.state.config.macos, {}).get("label", self.state.config.macos)
-        self.query_one("#install_btn", Button).label = f"Install {label}"
-        self.query_one("#install_btn").remove_class("hidden")
+        btn = self.query_one("#install_btn", Button)
+        btn.label = f"Install {label}"
+        btn.remove_class("hidden")
+        btn.focus()
 
     def _run_live_install(self) -> None:
         if self.state.apply_running:

--- a/src/osx_proxmox_next/planner.py
+++ b/src/osx_proxmox_next/planner.py
@@ -273,9 +273,9 @@ def _disk_steps(ctx: _DiskBuildContext, macos_label: str) -> list[PlanStep]:
             title="Validate storage target",
             argv=[
                 "bash", "-c",
-                f"pvesm status {shquote(ctx.config.storage)} > /dev/null 2>&1 || "
-                f"{{ echo 'ERROR: Storage {shquote(ctx.config.storage)} not found."
-                " Run pvesm status to list available storages.'; false; }}",
+                f"pvesm list {shquote(ctx.config.storage)} > /dev/null 2>&1 || "
+                f'{{ echo "ERROR: Storage {ctx.config.storage} not found.'
+                ' Run pvesm status to list available storages."; false; }}',
             ],
         ),
         PlanStep(
@@ -321,7 +321,11 @@ def build_post_install_plan(vmid: int) -> list[PlanStep]:
     return [
         PlanStep(
             title="Detach recovery disk",
-            argv=["qm", "set", vid, "--delete", "ide2"],
+            argv=[
+                "bash", "-c",
+                f"qm config {shquote(vid)} | grep -q '^ide2:' && "
+                f"qm set {shquote(vid)} --delete ide2 || true",
+            ],
             risk="action",
         ),
         PlanStep(

--- a/src/osx_proxmox_next/planner.py
+++ b/src/osx_proxmox_next/planner.py
@@ -217,6 +217,8 @@ def _recovery_steps(
                 # Trap to clean up loop device and temp dir on failure
                 "RLOOP=''; OC_REC=$(mktemp -d) && "
                 "trap '[ -n \"$RLOOP\" ] && { umount $OC_REC 2>/dev/null; losetup -d $RLOOP 2>/dev/null; }; rm -rf $OC_REC' EXIT; "
+                # Cleanup stale loops from previous failed runs (always runs, before python3)
+                f'for lo in $(losetup -j {shquote(str(recovery_raw))} -O NAME --noheadings 2>/dev/null); do umount -l $lo* 2>/dev/null; losetup -d $lo 2>/dev/null; done; '
                 # Fix HFS+ dirty/lock flags so Linux mounts read-write,
                 # then write OpenCore .contentFlavour + .contentDetails
                 "python3 -c '"
@@ -230,8 +232,6 @@ def _recovery_steps(
                 "a=(a|0x100)&~0x800; "
                 "f.seek(off); f.write(struct.pack(\">I\",a)); "
                 "f.close(); print(\"HFS+ flags fixed\")' && "
-                # Cleanup stale loops from previous failed runs
-                f'for lo in $(losetup -j {shquote(str(recovery_raw))} -O NAME --noheadings 2>/dev/null); do umount -l $lo* 2>/dev/null; losetup -d $lo 2>/dev/null; done; '
                 f'RLOOP=$(losetup -fP --show {shquote(str(recovery_raw))}) && '
                 "{ [ -b \"$RLOOP\" ] || { echo 'ERROR: losetup failed for recovery image. Hints: modprobe loop; losetup -a; ls /dev/loop*'; false; }; } && "
                 # Retry partprobe up to 5 times for slow storage (partprobe first, then check)
@@ -269,6 +269,15 @@ def _recovery_steps(
 def _disk_steps(ctx: _DiskBuildContext, macos_label: str) -> list[PlanStep]:
     """EFI/TPM disk, main disk, OpenCore build/import, and recovery import."""
     return [
+        PlanStep(
+            title="Validate storage target",
+            argv=[
+                "bash", "-c",
+                f"pvesm status {shquote(ctx.config.storage)} > /dev/null 2>&1 || "
+                f"{{ echo 'ERROR: Storage {shquote(ctx.config.storage)} not found."
+                " Run pvesm status to list available storages.'; false; }}",
+            ],
+        ),
         PlanStep(
             title="Attach EFI + TPM",
             argv=[

--- a/src/osx_proxmox_next/planner.py
+++ b/src/osx_proxmox_next/planner.py
@@ -315,9 +315,15 @@ def build_post_install_plan(vmid: int) -> list[PlanStep]:
 
     Switches from recovery-first (ide2;virtio0;ide0) to OpenCore-first
     (ide0;virtio0) so the VM boots into the installed macOS via OpenCore.
+    Detaches the recovery disk so OpenCore does not show a boot picker.
     """
     vid = str(vmid)
     return [
+        PlanStep(
+            title="Detach recovery disk",
+            argv=["qm", "set", vid, "--delete", "ide2"],
+            risk="action",
+        ),
         PlanStep(
             title="Set post-install boot order",
             argv=["qm", "set", vid, "--boot", POST_INSTALL_BOOT_ORDER],

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -860,20 +860,30 @@ def test_build_plan_intel_host_no_kvm_pv_flags(monkeypatch) -> None:
 # build_post_install_plan
 # ---------------------------------------------------------------------------
 
-def test_build_post_install_plan_single_step() -> None:
+def test_build_post_install_plan_two_steps() -> None:
     from osx_proxmox_next.planner import build_post_install_plan
     steps = build_post_install_plan(102)
-    assert len(steps) == 1
-    assert steps[0].title == "Set post-install boot order"
+    assert len(steps) == 2
+    assert steps[0].title == "Detach recovery disk"
+    assert steps[1].title == "Set post-install boot order"
+
+
+def test_build_post_install_plan_detaches_ide2() -> None:
+    from osx_proxmox_next.planner import build_post_install_plan
+    steps = build_post_install_plan(102)
+    cmd = steps[0].command
+    assert "--delete" in cmd
+    assert "ide2" in cmd
 
 
 def test_build_post_install_plan_correct_boot_order() -> None:
     from osx_proxmox_next.planner import build_post_install_plan
     steps = build_post_install_plan(102)
-    assert f"--boot '{POST_INSTALL_BOOT_ORDER}'" in steps[0].command
+    assert f"--boot '{POST_INSTALL_BOOT_ORDER}'" in steps[1].command
 
 
 def test_build_post_install_plan_targets_correct_vmid() -> None:
     from osx_proxmox_next.planner import build_post_install_plan
     steps = build_post_install_plan(999)
     assert "qm set 999" in steps[0].command
+    assert "qm set 999" in steps[1].command

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -62,7 +62,7 @@ def test_build_plan_storage_validation_is_first_disk_step() -> None:
     efi_idx = titles.index("Attach EFI + TPM")
     assert validate_idx < efi_idx
     validate_step = steps[validate_idx]
-    assert "pvesm status" in validate_step.command
+    assert "pvesm list" in validate_step.command
     assert "local-lvm" in validate_step.command
 
 
@@ -872,8 +872,8 @@ def test_build_post_install_plan_detaches_ide2() -> None:
     from osx_proxmox_next.planner import build_post_install_plan
     steps = build_post_install_plan(102)
     cmd = steps[0].command
-    assert "--delete" in cmd
-    assert "ide2" in cmd
+    assert "--delete ide2" in cmd
+    assert "ide2:" in cmd  # idempotency guard checks ^ide2:
 
 
 def test_build_post_install_plan_correct_boot_order() -> None:

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -44,6 +44,7 @@ def test_build_plan_rejects_invalid_config() -> None:
 def test_build_plan_includes_core_steps() -> None:
     steps = build_plan(_cfg("sequoia"))
     titles = [step.title for step in steps]
+    assert "Validate storage target" in titles
     assert "Create VM shell" in titles
     assert "Apply macOS hardware profile" in titles
     assert "Build OpenCore boot disk" in titles
@@ -52,6 +53,29 @@ def test_build_plan_includes_core_steps() -> None:
     assert "Import and attach macOS recovery" in titles
     assert "Set boot order" in titles
     assert any(step.command.startswith("qm start") for step in steps)
+
+
+def test_build_plan_storage_validation_is_first_disk_step() -> None:
+    steps = build_plan(_cfg("sequoia"))
+    titles = [step.title for step in steps]
+    validate_idx = titles.index("Validate storage target")
+    efi_idx = titles.index("Attach EFI + TPM")
+    assert validate_idx < efi_idx
+    validate_step = steps[validate_idx]
+    assert "pvesm status" in validate_step.command
+    assert "local-lvm" in validate_step.command
+
+
+def test_recovery_stamp_stale_cleanup_before_python3() -> None:
+    steps = build_plan(_cfg("sonoma"))
+    stamp = next(s for s in steps if s.title == "Stamp recovery with Apple icon flavour")
+    cmd = stamp.command
+    losetup_pos = cmd.index("losetup -j")
+    python3_pos = cmd.index("python3 -c")
+    assert losetup_pos < python3_pos, "stale loop cleanup must run before python3 HFS+ fix"
+    # Ensure RLOOP=$(losetup...) is after python3 (conditional on python3 success)
+    rloop_assign_pos = cmd.index("RLOOP=$(losetup")
+    assert python3_pos < rloop_assign_pos, "RLOOP must be set after python3 succeeds"
 
 
 def test_build_plan_tahoe_no_preview_warning() -> None:


### PR DESCRIPTION
## Summary

Fixes storage validation during install and resolves post-install boot picker issue.

Closes #84

## Changes

- fix(planner): use `pvesm list` for storage validation (was `pvesm status` which exits 0 for non-existent storage)
- fix(tui): focus install button when entering step 6
- fix(planner): detach recovery disk (ide2) on post-install — prevents OpenCore from showing boot picker on every reboot
- fix(planner): guard ide2 detach with existence check for idempotency

## Pre-Flight Results

| Check | Result |
|-------|--------|
| Build | N/A (Python, no build step) |
| Tests | PASS (all tests) |
| Coverage | ≥ 95% (enforced by pyproject.toml) |
| Code Review | PASS |

## Testing

- [ ] Manual test on dev environment
- [ ] Verify storage validation rejects bad storage name
- [ ] Verify post-install boot order (no picker shown after install)