### PR TITLE
fix(security): prevent shell injection in storage validation error message

### DIFF
--- a/src/osx_proxmox_next/planner.py
+++ b/src/osx_proxmox_next/planner.py
@@ -273,9 +273,10 @@ def _disk_steps(ctx: _DiskBuildContext, macos_label: str) -> list[PlanStep]:
             title="Validate storage target",
             argv=[
                 "bash", "-c",
-                f"pvesm list {shquote(ctx.config.storage)} > /dev/null 2>&1 || "
-                f'{{ echo "ERROR: Storage {ctx.config.storage} not found.'
-                ' Run pvesm status to list available storages."; false; }}',
+                f"STORAGE={shquote(ctx.config.storage)}; "
+                'pvesm list "$STORAGE" > /dev/null 2>&1 || '
+                '{ echo "ERROR: Storage $STORAGE not found.'
+                ' Run pvesm status to list available storages."; false; }',
             ],
         ),
         PlanStep(


### PR DESCRIPTION
## Summary

Fixes a shell injection vulnerability in the storage validation step.

The error message used raw f-string interpolation of `ctx.config.storage` inside a double-quoted bash string. A storage name containing `"` could escape the string context and inject arbitrary shell commands.

**Fix**: assign to a shell variable with `shquote()`, then reference via `"$STORAGE"`.

```bash
# Before (vulnerable) — a name like test"; rm -rf / breaks out
{ echo "ERROR: Storage test"; rm -rf / not found."; false; }

# After (safe) — user content never reaches the shell parser
STORAGE='test"; rm -rf /'; pvesm list "$STORAGE" || { echo "ERROR: Storage $STORAGE not found."; false; }
```

## Pre-Flight
- Tests: PASS (all)