### PR TITLE
fix(planner): use if/then/fi for ide2 detach, shquote recovery path in python3 snippet

### DIFF
--- a/src/osx_proxmox_next/planner.py
+++ b/src/osx_proxmox_next/planner.py
@@ -223,7 +223,7 @@ def _recovery_steps(
                 # then write OpenCore .contentFlavour + .contentDetails
                 "python3 -c '"
                 "import struct,subprocess; "
-                f'img="{recovery_raw}"; '
+                f"img={shquote(str(recovery_raw))}; "
                 "out=subprocess.check_output([\"sgdisk\",\"-i\",\"1\",img],text=True); "
                 "start=int([l for l in out.splitlines() if \"First sector\" in l][0].split(\":\")[1].split(\"(\")[0].strip()); "
                 "off=start*512+1024+4; "
@@ -323,8 +323,8 @@ def build_post_install_plan(vmid: int) -> list[PlanStep]:
             title="Detach recovery disk",
             argv=[
                 "bash", "-c",
-                f"qm config {shquote(vid)} | grep -q '^ide2:' && "
-                f"qm set {shquote(vid)} --delete ide2 || true",
+                f"if qm config {shquote(vid)} | grep -q '^ide2:'; then "
+                f"qm set {shquote(vid)} --delete ide2; fi",
             ],
             risk="action",
         ),

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -873,7 +873,8 @@ def test_build_post_install_plan_detaches_ide2() -> None:
     steps = build_post_install_plan(102)
     cmd = steps[0].command
     assert "--delete ide2" in cmd
-    assert "ide2:" in cmd  # idempotency guard checks ^ide2:
+    assert "'^ide2:'" in cmd  # idempotency guard
+    assert "if " in cmd  # propagates qm set failures (not masked by || true)
 
 
 def test_build_post_install_plan_correct_boot_order() -> None:


### PR DESCRIPTION
## Summary

Two correctness/security fixes found in post-session audit.

### Fix 1 — ide2 detach: `&& X || true` → `if/then/fi`

The previous `qm config | grep -q ... && qm set --delete ide2 || true` pattern silently exits 0 if `qm set --delete` fails (VM running, locked disk, permission error). Bash evaluates `&&`/`||` left-to-right with equal precedence:

```bash
# Before: (grep_ok && qm_set_FAILS) || true  →  false || true  →  0  (masked!)
# After:  if grep_ok; then qm_set; fi        →  propagates qm_set exit code
```

### Fix 2 — `recovery_raw` unquoted inside `python3 -c` shell string

`planner.py:226` embedded `recovery_raw` as a bare f-string inside a bash single-quoted block. A path containing `'` would terminate the outer single-quote context. Changed to `shquote(str(recovery_raw))` — consistent with all other uses of `recovery_raw` in the same function.

## Pre-Flight
- Tests: PASS (all)