### PR TITLE
fix(planner): pass recovery path via env var to avoid bash quoting conflict in python3 snippet

### DIFF
--- a/src/osx_proxmox_next/planner.py
+++ b/src/osx_proxmox_next/planner.py
@@ -221,9 +221,9 @@ def _recovery_steps(
                 f'for lo in $(losetup -j {shquote(str(recovery_raw))} -O NAME --noheadings 2>/dev/null); do umount -l $lo* 2>/dev/null; losetup -d $lo 2>/dev/null; done; '
                 # Fix HFS+ dirty/lock flags so Linux mounts read-write,
                 # then write OpenCore .contentFlavour + .contentDetails
-                "python3 -c '"
-                "import struct,subprocess; "
-                f"img={shquote(str(recovery_raw))}; "
+                f"RECOVERY_IMG={shquote(str(recovery_raw))} python3 -c '"
+                "import struct,subprocess,os; "
+                "img=os.environ[\"RECOVERY_IMG\"]; "
                 "out=subprocess.check_output([\"sgdisk\",\"-i\",\"1\",img],text=True); "
                 "start=int([l for l in out.splitlines() if \"First sector\" in l][0].split(\":\")[1].split(\"(\")[0].strip()); "
                 "off=start*512+1024+4; "


### PR DESCRIPTION
## Summary

Fixes a regression introduced in #88.

The previous fix used `shquote(recovery_raw)` to escape the path, producing a single-quoted string like `'/path/to/file'`. However, the python3 code lives inside an outer bash single-quoted block (`python3 -c '...'`). The single quotes from `shquote` terminated and restarted that outer block, causing the path to be injected unquoted into the bash token stream — resulting in a Python SyntaxError on every invocation.

**Fix**: set `RECOVERY_IMG` as an inline env var before `python3`, then read it with `os.environ["RECOVERY_IMG"]` inside the single-quoted block. `shquote` correctly escapes the assignment (which is in normal bash context), and the inner Python code never touches the bash quoting boundary.

```bash
# Before (broken — shquote single quotes terminate the outer '...' block)
python3 -c 'import struct,subprocess; img='/path/to/file'; ...'

# After (safe — path never enters the single-quoted block)
RECOVERY_IMG='/path/to/file' python3 -c 'import struct,subprocess,os; img=os.environ["RECOVERY_IMG"]; ...'
```

## Pre-Flight
- Tests: PASS (all)