### PR TITLE
fix: star-history badge, AllowSetDefault, Ko-fi badge tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -769,6 +769,8 @@ This project is for **testing, lab use, and learning**. Respect Apple licensing 
 
 ---
 
-## ⭐ Star History
+## ⭐ Stars
 
-[![Star History Chart](https://api.star-history.com/svg?repos=lucid-fabrics/osx-proxmox-next&type=date&legend=top-left)](https://www.star-history.com/#lucid-fabrics/osx-proxmox-next&type=date&legend=top-left)
+[![Stars](https://img.shields.io/github/stars/lucid-fabrics/osx-proxmox-next?style=social)](https://github.com/lucid-fabrics/osx-proxmox-next/stargazers)
+
+Track the chart on [star-history.com](https://www.star-history.com/#lucid-fabrics/osx-proxmox-next&type=date).

--- a/README.md
+++ b/README.md
@@ -376,6 +376,21 @@ Boot media path or order mismatch. Ensure OpenCore is on `ide0` and recovery on 
 </details>
 
 <details>
+<summary><strong>Loops back to Recovery after the install finishes</strong></summary>
+
+The install succeeded but OpenCore is still booting the on-disk Recovery volume. macOS only sets the startup disk once it boots the new system for real, and it never got there, so the bootloader keeps falling back to Recovery. `post-install` only reorders the Proxmox boot devices, it cannot change the bootloader's saved choice inside the VM.
+
+Fix it from the VM console:
+
+1. Reboot and wait for the OpenCore picker (the screen with the disk icons).
+2. Press **spacebar** to reveal all entries, select **macOS** (not "Install macOS" or "Recovery"), and boot it.
+3. Optionally press **Ctrl+Enter** on that entry to make it the default so the choice sticks.
+4. If it still returns to Recovery, pick **Reset NVRAM** in the picker first, reboot, then select **macOS** again.
+
+Once macOS reaches the Setup Assistant and you finish setup, later boots go straight to macOS.
+</details>
+
+<details>
 <summary><strong>"Guest has not initialized the display"</strong></summary>
 
 Boot/display profile mismatch during early boot. Use `vga: std` for stable noVNC during installation.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
   <a href="https://lucid-fabrics.github.io/osx-proxmox-next/">
     <img alt="Documentation" src="https://img.shields.io/badge/Docs-Read%20the%20Docs-blue?logo=readthedocs&logoColor=white">
   </a>
-  <a href="https://ko-fi.com/lucidfabrics">
+  <a href="https://ko-fi.com/s/84fe857595">
     <img alt="Support on Ko-fi" src="https://img.shields.io/badge/Support-Ko--fi-FF5E5B?logo=ko-fi&logoColor=white">
   </a>
   <a href="https://buymeacoffee.com/lucidfabrics">
@@ -33,7 +33,7 @@
 </p>
 
 <p align="center">
-  <a href="https://ko-fi.com/lucidfabrics">
+  <a href="https://ko-fi.com/s/84fe857595">
     <img alt="GPU Passthrough Fund progress" src="https://api.lucidfabrics.com/api/public/progress/osx-proxmox-next/svg?v=2" width="600">
   </a>
 </p>
@@ -72,7 +72,7 @@ osx-proxmox-next replaces all of it with a 6-step wizard that runs on your Proxm
 
 <p align="center">
   <strong>If this already looks better than what you've been doing — ⭐ star the repo and help others find it.</strong><br><br>
-  <a href="https://ko-fi.com/lucidfabrics">
+  <a href="https://ko-fi.com/s/84fe857595">
     <img src="https://ko-fi.com/img/githubbutton_sm.svg" alt="Support on Ko-fi">
   </a>
   &nbsp;&nbsp;
@@ -122,7 +122,7 @@ osx-proxmox-next replaces all of it with a 6-step wizard that runs on your Proxm
 
 <p align="center">
   Built solo, maintained in free time. If it saved you an afternoon:<br><br>
-  <a href="https://ko-fi.com/lucidfabrics">
+  <a href="https://ko-fi.com/s/84fe857595">
     <img src="https://ko-fi.com/img/githubbutton_sm.svg" alt="Support on Ko-fi">
   </a>
   &nbsp;&nbsp;
@@ -143,7 +143,7 @@ bash -c "$(curl -fsSL https://raw.githubusercontent.com/lucid-fabrics/osx-proxmo
 
 This clones the repo, sets up a Python venv, and launches the TUI wizard.
 
-> Built solo and maintained in my free time. If it saves you an afternoon of `qm` commands, [a coffee helps](https://ko-fi.com/lucidfabrics) or a [coffee on BMC](https://buymeacoffee.com/lucidfabrics). ☕
+> Built solo and maintained in my free time. If it saves you an afternoon of `qm` commands, [a coffee helps](https://ko-fi.com/s/84fe857595) or a [coffee on BMC](https://buymeacoffee.com/lucidfabrics). ☕
 
 ### 🐚 Bash Alternative
 
@@ -714,7 +714,7 @@ This project is free and open source. Sponsors keep it alive and shape what gets
     <img src="https://img.shields.io/badge/Buy%20Me%20a%20Coffee-FFDD00?logo=buymeacoffee&logoColor=black" alt="Buy Me a Coffee">
   </a>
   &nbsp;
-  <a href="https://ko-fi.com/lucidfabrics">
+  <a href="https://ko-fi.com/s/84fe857595">
     <img src="https://img.shields.io/badge/Support-Ko--fi-FF5E5B?logo=ko-fi&logoColor=white" alt="Support on Ko-fi">
   </a>
   &nbsp;
@@ -737,7 +737,7 @@ This project is for **testing, lab use, and learning**. Respect Apple licensing 
 <p align="center">
   This project is built and maintained solo. No company, no team — just one dev who got tired of manual <code>qm</code> configs.<br>
   If it saved you time, a coffee keeps it going:<br><br>
-  <a href="https://ko-fi.com/lucidfabrics">
+  <a href="https://ko-fi.com/s/84fe857595">
     <img src="https://ko-fi.com/img/githubbutton_sm.svg" alt="Support me on Ko-fi">
   </a>
   &nbsp;&nbsp;

--- a/src/osx_proxmox_next/script_renderer.py
+++ b/src/osx_proxmox_next/script_renderer.py
@@ -151,6 +151,7 @@ def _plist_patch_script(
         "p[\"Misc\"][\"Boot\"][\"Timeout\"]=15; "
         "p[\"Misc\"][\"Boot\"][\"PickerAttributes\"]=17; "
         "p[\"Misc\"][\"Boot\"][\"HideAuxiliary\"]=True; "
+        "p[\"Misc\"][\"Security\"][\"AllowSetDefault\"]=True; "
         "p[\"Misc\"][\"Boot\"][\"PickerMode\"]=\"External\"; "
         "p[\"Misc\"][\"Boot\"][\"PickerVariant\"]=\"Acidanthera\\\\Syrah\"; "
         "p[\"NVRAM\"][\"Add\"][\"7C436110-AB2A-4BBB-A880-FE41995C9F82\"][\"csr-active-config\"]=b\"\\x67\\x0f\\x00\\x00\"; "

--- a/tests/test_script_renderer.py
+++ b/tests/test_script_renderer.py
@@ -122,6 +122,13 @@ def test_plist_patch_script_sets_scan_policy() -> None:
     assert "ScanPolicy" in result
 
 
+def test_plist_patch_script_allows_set_default() -> None:
+    # Lets the user persist "macOS" as the boot entry (Ctrl+Enter in the picker)
+    # so a fresh install stops falling back to Recovery on reboot.
+    result = _plist_patch_script()
+    assert "AllowSetDefault" in result
+
+
 def test_plist_patch_script_verbose_boot_adds_flag() -> None:
     result_verbose = _plist_patch_script(verbose_boot=True)
     result_normal = _plist_patch_script(verbose_boot=False)


### PR DESCRIPTION
## Summary
Fix three README/boot issues: badge tracking, recovery boot loop, and broken Star History embed.

## Changes
- 9a99388 fix(readme): point Ko-fi links to direct link for badge tracking
- 6e6bf92 fix(opencore): enable AllowSetDefault so macOS boot entry persists
- 334a207 fix(readme): replace broken star-history chart with shields.io star count badge

## Pre-Flight Results
| Check | Result |
|-------|--------|
| Tests | PASS (862 passed, coverage ≥ 95%) |
| Merge Conflicts | CLEAN (merge-tree OK) |

## Testing
- [ ] Manual test on dev environment
