### PR TITLE
fix(readme): flatten sponsors layout - drop past supporters subsection

### DIFF
--- a/README.md
+++ b/README.md
@@ -740,10 +740,9 @@ This project is free and open source. Sponsors keep it alive and shape what gets
 
 **Sponsors:**
 
-- _No GitHub Sponsors yet. [Be the first!](https://github.com/sponsors/lucid-fabrics)_
-
-**Past supporters (Ko-fi, BMC, one-time):**
 - ❤️ [SuperDooper](https://github.com/superdooper86)
+
+_Want to join them? [Sponsor on GitHub](https://github.com/sponsors/lucid-fabrics)_
 ---
 
 ## ⚖️ Disclaimer

--- a/scripts/sync_sponsors.py
+++ b/scripts/sync_sponsors.py
@@ -133,21 +133,33 @@ def load_manual() -> list[str]:
 
 
 def render_block(github: list[dict], manual: list[str]) -> str:
-    """Build the markdown block that replaces the Sponsors section."""
+    """Build the markdown block that replaces the Sponsors section.
+
+    Layout:
+      **Sponsors:**
+      - github sponsors (with tier + monthly amount)
+      - manual supporters (from SPONSORS.md, no tier info)
+      If no sponsors at all, show a CTA placeholder.
+    """
     github = sorted(github, key=lambda s: (-s["amount"], s["login"].lower()))
     out = ["**Sponsors:**", ""]
-    if github:
-        for s in github:
-            out.append(
-                f"- ❤️ [{s['login']}](https://github.com/{s['login']}) "
-                f"| {s['tier']} (${s['amount']}/mo)"
-            )
-    else:
-        out.append("- _No GitHub Sponsors yet. [Be the first!](https://github.com/sponsors/lucid-fabrics)_")
 
-    if manual:
-        out += ["", "**Past supporters (Ko-fi, BMC, one-time):**"]
-        out += [f"- ❤️ {name}" for name in manual]
+    if not github and not manual:
+        out.append("- _No GitHub Sponsors yet. [Be the first!](https://github.com/sponsors/lucid-fabrics)_")
+        return "\n".join(out)
+
+    for s in github:
+        out.append(
+            f"- ❤️ [{s['login']}](https://github.com/{s['login']}) "
+            f"| {s['tier']} (${s['amount']}/mo)"
+        )
+
+    for name in manual:
+        out.append(f"- ❤️ {name}")
+
+    if not github and manual:
+        # Manual-only: hint that GitHub Sponsors is the recurring option.
+        out += ["", "_Want to join them? [Sponsor on GitHub](https://github.com/sponsors/lucid-fabrics)_"]
 
     return "\n".join(out)
 

--- a/tests/scripts/test_sync_sponsors.py
+++ b/tests/scripts/test_sync_sponsors.py
@@ -55,9 +55,12 @@ def test_render_block_empty_github_shows_placeholder(sync_module):
 def test_render_block_with_manual_entries(sync_module):
     manual = ["Charlie", "[Dora](https://example.com/dora)"]
     block = sync_module.render_block([], manual)
-    assert "**Past supporters (Ko-fi, BMC, one-time):**" in block
+    # Manual entries render directly under the main Sponsors header.
+    assert "**Past supporters" not in block
     assert "❤️ Charlie" in block
     assert "❤️ [Dora](https://example.com/dora)" in block
+    # Manual-only path shows the recurring-sponsor CTA.
+    assert "Sponsor on GitHub" in block
 
 
 def test_render_block_combined(sync_module):
@@ -65,8 +68,20 @@ def test_render_block_combined(sync_module):
     manual = ["Bob"]
     block = sync_module.render_block(github, manual)
     assert "[alice]" in block
-    assert "**Past supporters" in block
+    # When GitHub sponsors exist, the CTA is suppressed.
+    assert "Sponsor on GitHub" not in block
     assert "❤️ Bob" in block
+
+
+def test_render_block_no_split_subsection(sync_module):
+    """No 'Past supporters' subsection - all entries share the main header."""
+    block = sync_module.render_block(
+        [{"login": "alice", "amount": 5, "tier": "T"}],
+        ["Bob"],
+    )
+    assert "**Sponsors:**" in block
+    assert "**Past supporters" not in block
+    assert block.count("❤️") == 2
 
 
 def test_update_readme_replaces_block(tmp_path, sync_module):


### PR DESCRIPTION
## Summary
Manual supporters (from SPONSORS.md) now render directly under the main
**Sponsors:** header instead of a hidden "Past supporters" subsection.

## Before
```
**Sponsors:**
- _No GitHub Sponsors yet. [Be the first!]..._

**Past supporters (Ko-fi, BMC, one-time):**
- ❤️ [SuperDooper](https://github.com/superdooper86)
```

## After
```
**Sponsors:**
- ❤️ [SuperDooper](https://github.com/superdooper86)

_Want to join them? [Sponsor on GitHub](https://github.com/sponsors/lucid-fabrics)_
```

## Changes
- `scripts/sync_sponsors.py`: drop "Past supporters" subheader, merge manual entries into the main list. Add a CTA hint when only manual entries exist.
- `tests/scripts/test_sync_sponsors.py`: updated render tests, added `test_render_block_no_split_subsection`.
- `README.md`: regenerated.

## Testing
- [x] pytest 876 passed, coverage gate green