### PR TITLE
chore(gitignore): exclude .playwright-mcp/ and .wrangler/ tool caches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ htmlcov/
 # generated runtime artifacts
 generated/
 pytest-of-*/
+
+# tool caches
+.playwright-mcp/
+.wrangler/


### PR DESCRIPTION
## Summary
Exclude Playwright MCP and Wrangler tool caches from git tracking. Both directories are runtime caches that should never be committed.

## Changes
- `.gitignore`: add `.playwright-mcp/` and `.wrangler/`

## Context
These caches appeared as untracked files in `git status` after running the Playwright MCP browser and `wrangler deploy` against the donation-webhooks worker. Keeping them ignored prevents accidental commits of large binary caches.

## Pre-Flight Results
| Check | Result |
|-------|--------|
| Tests | PASS (888 passed) |

Closes #99
