### PR TITLE
fix(install): detect logical sector size for OpenCore GPT header repair

### DIFF
--- a/scripts/bash/osx-proxmox-next.sh
+++ b/scripts/bash/osx-proxmox-next.sh
@@ -1205,10 +1205,14 @@ OC_IMPORT_OUT="$("${IMPORT_CMD[@]}" "$VMID" "$OC_DISK" "$STORAGE" --format raw 2
 }
 OC_DISK_REF="$(get_disk_ref "$OC_IMPORT_OUT" "$STORAGE" "$VMID" "OpenCore")"
 qm set "$VMID" --ide0 "${OC_DISK_REF},media=disk" >/dev/null
-# Fix GPT header corruption on thin-provisioned LVM after importdisk
+# Fix GPT header corruption on thin-provisioned LVM after importdisk.
+# 4Kn drives / zvols / some LVM-thin backends report a 4096-byte logical
+# sector size; a hardcoded bs=512 write fails with "Invalid argument" on
+# those (silently, since stderr is discarded), leaving the GPT corrupt.
 OC_DEV=$(pvesm path "$OC_DISK_REF" 2>/dev/null) || true
 if [ -n "$OC_DEV" ] && [ -b "$OC_DEV" ]; then
-  dd if="$OC_DISK" of="$OC_DEV" bs=512 count=2048 conv=notrunc 2>/dev/null || true
+  OC_SS=$(blockdev --getss "$OC_DEV" 2>/dev/null); OC_SS=${OC_SS:-512}
+  dd if="$OC_DISK" of="$OC_DEV" bs="$OC_SS" count=$((1048576 / OC_SS)) conv=notrunc 2>/dev/null || true
 fi
 msg_ok "Attached OpenCore disk (ide0)"
 

--- a/src/osx_proxmox_next/planner.py
+++ b/src/osx_proxmox_next/planner.py
@@ -195,7 +195,12 @@ def _opencore_steps(ctx: _DiskBuildContext) -> list[PlanStep]:
                 # with "File exists" because qm importdisk already created it.)
                 'DEV=$(pvesm path "$REF") && '
                 f'if [[ "$DEV" != rbd:* ]]; then '
-                f'dd if={shquote(str(ctx.oc_disk))} of="$DEV" bs=512 count=2048 conv=notrunc 2>/dev/null; '
+                # 4Kn drives / zvols / some LVM-thin backends report a
+                # 4096-byte logical sector size; a hardcoded bs=512 write
+                # fails with "Invalid argument" on those (silently, since
+                # stderr is discarded), leaving the GPT header corrupt.
+                'SS=$(blockdev --getss "$DEV" 2>/dev/null); SS=${SS:-512}; '
+                f'dd if={shquote(str(ctx.oc_disk))} of="$DEV" bs="$SS" count=$((1048576 / SS)) conv=notrunc 2>/dev/null; '
                 f'fi',
             ],
         ),

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -162,6 +162,13 @@ def test_build_plan_uses_importdisk_for_opencore(monkeypatch) -> None:
     # an already-imported RBD volume); only non-RBD paths run dd.
     assert "qemu-img dd" not in oc.command
     assert '[[ "$DEV" != rbd:* ]]' in oc.command
+    # dd must use the destination device's actual logical sector size, not a
+    # hardcoded bs=512 - 4Kn drives/zvols/some LVM-thin backends reject
+    # 512-byte writes with "Invalid argument", corrupting the GPT header.
+    assert "blockdev --getss" in oc.command
+    assert "bs=512" not in oc.command
+    assert 'bs="$SS"' in oc.command
+    assert "count=$((1048576 / SS))" in oc.command
 
 
 def test_build_plan_uses_importdisk_for_recovery(monkeypatch) -> None:


### PR DESCRIPTION
The GPT-header-repair dd after importing the OpenCore boot disk hardcoded bs=512. On storage backends that report a 4096-byte logical sector size (4Kn NVMe drives, zvols, some LVM-thin setups), the 512-byte write is rejected with "Invalid argument" - silently, since stderr is discarded - leaving the imported disk's GPT header corrupt. Query the destination device's actual sector size via blockdev --getss and size bs/count to match, keeping the same 1MiB total write.

Applies to both the Python planner and the standalone bash installer.