### PR TITLE
fix(packaging): include app.tcss and py.typed in wheel builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,5 +54,8 @@ osx-next-cli = "osx_proxmox_next.cli:run_cli"
 [tool.setuptools.packages.find]
 where = ["src"]
 
+[tool.setuptools.package-data]
+osx_proxmox_next = ["*.tcss", "py.typed"]
+
 [tool.pytest.ini_options]
 addopts = "--cov=osx_proxmox_next --cov-branch --cov-report=term-missing --cov-fail-under=95"


### PR DESCRIPTION
## Summary
- A Ko-fi supporter reported a "missing app.tcss package file" error
- `pyproject.toml` had no `package-data` declaration, so setuptools only bundled `.py` files into wheels, `app.tcss` (the Textual CSS file) and `py.typed` were silently dropped from any non-editable install
- The documented `install.sh` path (`pip install -e`) was never affected, editable installs point straight at the source tree
- But `pip install .`, `pip install git+https://...`, or `pipx install .` all built a broken package: `app.py` present, `app.tcss` missing, Textual's `CSS_PATH` pointed at a nonexistent file

## Testing
- [x] Built a wheel before the fix, confirmed `app.tcss` absent
- [x] Built a wheel after the fix, confirmed both `app.tcss` and `py.typed` present
- [x] Installed the fixed wheel non-editable in a clean venv, confirmed `CSS_PATH` resolves and the file exists
- [x] `pytest` passes (888 passed, coverage 97.83%)