### PR TITLE
fix(cli): add --version to osx-next, correct issue template command

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,7 +11,7 @@ body:
     id: version
     attributes:
       label: osx-proxmox-next version
-      description: Run `osx-proxmox-next --version`
+      description: Run `osx-next --version` (or `osx-next-cli --version`)
       placeholder: "0.25.0"
     validations:
       required: true

--- a/src/osx_proxmox_next/app.py
+++ b/src/osx_proxmox_next/app.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import sys
 from pathlib import Path
 from threading import Thread
 
@@ -11,6 +12,7 @@ from textual.containers import Container
 from textual.reactive import reactive
 from textual.widgets import Button, Checkbox, Header, Input, ProgressBar, Static
 
+from . import __version__
 from ._edit_mixin import EditModeMixin
 from ._manage_mixin import ManageModeMixin
 from ._wizard_mixin import WizardStepsMixin
@@ -402,4 +404,7 @@ class NextApp(WizardStepsMixin, ManageModeMixin, EditModeMixin, App):
 
 
 def run() -> None:
+    if "--version" in sys.argv[1:]:
+        print(f"osx-next {__version__}")
+        return
     NextApp().run()

--- a/tests/test_app_wizard.py
+++ b/tests/test_app_wizard.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import sys
 import time
 from pathlib import Path
 from unittest.mock import patch
@@ -81,7 +82,7 @@ async def _advance_to_step(pilot, app, target_step, monkeypatch=None):
         if monkeypatch:
             monkeypatch.setattr(app_module, "required_assets", lambda cfg: [])
             monkeypatch.setattr(app_module, "validate_config", lambda cfg: [])
-        # Scroll button into view — step 4 form can exceed viewport height
+        # Scroll button into view - step 4 form can exceed viewport height
         app.query_one("#next_btn_4").scroll_visible()
         for _ in range(3):
             await pilot.pause()
@@ -1536,7 +1537,7 @@ def test_detect_vmid_boundary_high(monkeypatch) -> None:
 
     async def _run() -> None:
         app = NextApp()
-        # max VMID is 999999, so next would be 1000000 which overflows — returns DEFAULT_VMID
+        # max VMID is 999999, so next would be 1000000 which overflows - returns DEFAULT_VMID
         assert app._detect_next_vmid() == DEFAULT_VMID
 
     asyncio.run(_run())
@@ -1681,6 +1682,19 @@ def test_run_function(monkeypatch) -> None:
     monkeypatch.setattr(NextApp, "run", fake_run)
     app_mod.run()
     assert called[0] is True
+
+
+def test_run_version_flag(monkeypatch, capsys) -> None:
+    """osx-next --version prints the version and exits without launching the TUI (#106)."""
+    from osx_proxmox_next import __version__, app as app_mod
+
+    def fail_run(self):
+        raise AssertionError("TUI must not launch with --version")
+
+    monkeypatch.setattr(NextApp, "run", fail_run)
+    monkeypatch.setattr(sys, "argv", ["osx-next", "--version"])
+    app_mod.run()
+    assert capsys.readouterr().out.strip() == f"osx-next {__version__}"
 
 
 def test_wizard_state_defaults() -> None:

--- a/tests/test_issue_template.py
+++ b/tests/test_issue_template.py
@@ -1,0 +1,32 @@
+"""Guard: issue templates must only reference commands this package installs (#106)."""
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def _entry_points() -> set:
+    text = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    section = re.search(r"\[project\.scripts\](.*?)(?:\n\[|\Z)", text, re.DOTALL)
+    assert section, "pyproject.toml has no [project.scripts] section"
+    return set(re.findall(r"^([\w-]+)\s*=", section.group(1), re.MULTILINE))
+
+
+def test_templates_reference_only_installed_commands():
+    scripts = _entry_points()
+    assert scripts
+    templates = list((ROOT / ".github" / "ISSUE_TEMPLATE").glob("*.yml"))
+    assert templates, "no issue templates found"
+    for template in templates:
+        for cmd in re.findall(r"`(osx-[\w-]+)", template.read_text(encoding="utf-8")):
+            assert cmd in scripts, (
+                f"{template.name} references {cmd!r}, which is not an installed "
+                f"command (pyproject scripts: {sorted(scripts)})"
+            )
+
+
+def test_bug_report_version_field_uses_real_command():
+    text = (ROOT / ".github" / "ISSUE_TEMPLATE" / "bug_report.yml").read_text(encoding="utf-8")
+    match = re.search(r"description: Run `(osx-[\w-]+) --version`", text)
+    assert match, "bug_report.yml version field must instruct running an installed command with --version"
+    assert match.group(1) in _entry_points()


### PR DESCRIPTION
## Summary
Fixes #106. The bug report template told users to run `osx-proxmox-next --version`, a command that does not exist, and `osx-next --version` launched the TUI instead of printing the version.

## Changes
- `osx-next --version` now prints the installed version and exits (`osx-next-cli --version` already worked)
- Issue template now instructs `osx-next --version` (or `osx-next-cli --version`)
- Guard tests: issue templates can only reference commands declared in `[project.scripts]`, so the template cannot drift again

## Testing
- [x] 904 tests pass, coverage 97.86% (gate 95%)
- [x] Both version commands verified locally