### PR TITLE
docs: add Google Search Console verification file

### DIFF
--- a/docs/static/google634984d250b1a3a7.html
+++ b/docs/static/google634984d250b1a3a7.html
@@ -1,0 +1,1 @@
+google-site-verification: google634984d250b1a3a7.html


### PR DESCRIPTION
## Summary
Site ownership verification file for Google Search Console, needed to submit the sitemap.

## Changes
- `docs/static/google634984d250b1a3a7.html` deploys to the site root

## Testing
- [x] Standard Google token file, no build impact