### PR TITLE
fix(install): don't rm -rf REPO_DIR out from under the caller's shell

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -72,10 +72,15 @@ launch() {
 }
 
 nuke_stale() {
-  # Remove previous install to prevent stale code/venv from persisting
+  # Clear previous install to prevent stale code/venv from persisting.
+  # Empty the directory rather than rm -rf'ing it: if the invoking shell's
+  # cwd is $REPO_DIR (e.g. user cloned it manually and cd'd in), removing
+  # the directory itself leaves that shell's getcwd() unresolvable, which
+  # breaks any later command needing it (pushd, pwd -P, etc.) even after
+  # this script exits.
   if [[ -d "$REPO_DIR" ]]; then
     log "Removing previous install..."
-    rm -rf "$REPO_DIR"
+    find "$REPO_DIR" -mindepth 1 -delete
   fi
 }
 

--- a/scripts/bash/osx-proxmox-next.sh
+++ b/scripts/bash/osx-proxmox-next.sh
@@ -788,6 +788,12 @@ with open(path, 'wb') as f:
   msg_ok "Built OpenCore boot disk"
 }
 
+# pushd needs a resolvable cwd to save onto the dir stack; if the caller's
+# shell is sitting in a directory that got removed from under it (e.g. by a
+# prior install script deleting its own repo checkout), getcwd() fails and
+# pushd aborts. Land somewhere known-good first so that can't happen here.
+cd "${HOME:-/root}" 2>/dev/null || cd /
+
 TEMP_DIR=$(mktemp -d)
 pushd "$TEMP_DIR" >/dev/null
 


### PR DESCRIPTION
## Summary
- `nuke_stale()` in `install.sh` ran `rm -rf "$REPO_DIR"`, which deletes the directory even when the invoking shell's cwd is inside it (e.g. user manually cloned to `/root/osx-proxmox-next` and `cd`'d in). That leaves `getcwd()` unresolvable for that shell, breaking any later command needing it.
- Reported exact error match: `pushd: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory` at `scripts/bash/osx-proxmox-next.sh:792`.
- Fix: empty `$REPO_DIR`'s contents instead of removing the directory itself, so the caller's cwd stays valid. `git clone` into an existing empty directory works fine.
- Added a defense-in-depth guard in `scripts/bash/osx-proxmox-next.sh`: `cd "$HOME" || cd /` before the script's own `pushd`, so an already-broken cwd from any cause can't wedge it either.

Fixes #112

## Testing
- [x] `pytest`: 904 passed, 97.86% coverage (>=95% gate)
- [x] `shellcheck install.sh`: clean
- [x] Reproduced the exact bug live on a real Proxmox node (pve-mirna, PVE 9.1.7): `rm -rf` of cwd + new `bash -c` process hit the identical `getcwd` error text
- [x] Confirmed the fixed `nuke_stale` (find -delete) no longer breaks cwd in the same scenario
- [x] Confirmed the `cd $HOME` guard recovers even in the worst case where cwd is already broken