### PR TITLE
fix(defaults): detect Xeon Scalable HEDT livelock

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,15 +185,16 @@ Same VM creation logic (OpenCore + osrecovery + SMBIOS), whiptail menus, no venv
 | Storage | 64 GB free | 128+ GB SSD/NVMe |
 | GPU | Integrated | Discrete (for passthrough) |
 
-> **AMD CPUs** are fully supported. The tool auto-detects your CPU vendor and applies the correct configuration (Cascadelake-Server emulation for AMD, native host passthrough for Intel). **Xeon and pre-Skylake Intel CPUs** are also handled automatically: most Xeons stay on `-cpu host`, real HEDT chips (Xeon E5/E7 v2-v4, dual-socket/multi-die parts) get a fixed emulated CPU model instead, since `-cpu host` leaks their genuine multi-package topology and can livelock macOS's scheduler during install. Older consumer Intel gets Penryn mode, and non-HEDT Xeon/legacy Intel get `e1000` instead of `vmxnet3` for reliable network during installation.
+> **AMD CPUs** are fully supported. The tool auto-detects your CPU vendor and applies the correct configuration (Cascadelake-Server emulation for AMD, native host passthrough for Intel). **Xeon and pre-Skylake Intel CPUs** are also handled automatically: workstation Xeons (E3, W, D series) stay on `-cpu host`, while multi-socket-capable parts (Xeon E5/E7 v2-v4 HEDT and Xeon Scalable: Platinum/Gold/Silver/Bronze) get a fixed emulated CPU model instead, since `-cpu host` leaks their genuine multi-package topology and can livelock macOS's scheduler during install. Older consumer Intel gets Penryn mode, and Xeon/legacy Intel get `e1000` instead of `vmxnet3` for reliable network during installation. Use `--cpu-model` to override any auto-detected choice.
 
 ### CPU Compatibility
 
 | CPU Type | Support | QEMU Mode | NIC |
 |----------|---------|-----------|-----|
 | Modern Intel (Skylake+) | Full | `-cpu host` (native passthrough) | vmxnet3 |
-| Intel Xeon (non-HEDT) | Full | `-cpu host` (native passthrough) | e1000 |
+| Intel Xeon workstation (E3, W, D) | Full | `-cpu host` (native passthrough) | e1000 |
 | Intel Xeon E5/E7 v2-v4 (HEDT, dual-socket) | Full | Fixed emulated model (Broadwell-noTSX / Haswell-noTSX) | e1000 |
+| Intel Xeon Scalable (Platinum/Gold/Silver/Bronze) | Full | Fixed emulated model (Skylake-Client-noTSX-IBRS) | e1000 |
 | Pre-Skylake Intel (Broadwell, Haswell, etc.) | Full | Penryn mode | e1000 |
 | AMD (any) | Full | Cascadelake-Server emulation | vmxnet3 |
 | Apple Silicon (ARM Proxmox) | Not supported | n/a | n/a |

--- a/scripts/bash/osx-proxmox-next.sh
+++ b/scripts/bash/osx-proxmox-next.sh
@@ -351,13 +351,15 @@ function detect_cpu_needs_emulation() {
   echo "no"
 }
 
-# Real Xeon E5/E7 v2-v4 HEDT chips (dual-socket/multi-die parts) leak their
+# Real Xeon E5/E7 v2-v4 HEDT chips and Xeon Scalable (Skylake-SP and later:
+# Platinum/Gold/Silver/Bronze) are multi-socket-capable parts that leak their
 # genuine multi-package topology through -cpu host. Combined with a
 # multi-socket-capable SMBIOS (MacPro7,1), XNU's scheduler can livelock
 # during heavy multithreaded I/O (the installer copy phase spins at 100%
-# CPU with zero disk/network progress). A fixed emulated model avoids this;
-# these exact overrides match the known-working profile from
-# github.com/mchiappinam/proxmox-macos.
+# CPU with zero disk/network progress). A fixed emulated model avoids this.
+# E5/E7 overrides match the known-working profile from
+# github.com/mchiappinam/proxmox-macos; the Scalable override is the same
+# idea, confirmed working on a dual-socket Cascade Lake-SP host.
 function detect_cpu_xeon_hedt_model() {
   local model_name
   model_name=$(awk -F: '/^model name/{print $2; exit}' /proc/cpuinfo 2>/dev/null)
@@ -365,6 +367,8 @@ function detect_cpu_xeon_hedt_model() {
     echo "Haswell-noTSX,model=158,stepping=3"
   elif echo "$model_name" | grep -qE "Xeon.*E[57][ -]*[0-9]+ *v[34]"; then
     echo "Broadwell-noTSX,model=158"
+  elif echo "$model_name" | grep -qE "Xeon.*(Platinum|Gold|Silver|Bronze)[ -]*[0-9]{4}"; then
+    echo "Skylake-Client-noTSX-IBRS"
   else
     echo ""
   fi

--- a/src/osx_proxmox_next/cli.py
+++ b/src/osx_proxmox_next/cli.py
@@ -328,6 +328,8 @@ def _print_cpu_info(args: argparse.Namespace, config: VmConfig) -> None:
             cpu_mode = f"override: {config.cpu_model}"
         elif cpu.needs_emulated_cpu:
             cpu_mode = "Cascadelake-Server emulation"
+        elif cpu.xeon_hedt_model:
+            cpu_mode = f"{cpu.xeon_hedt_model.split(',')[0]} (multi-socket Xeon profile)"
         else:
             cpu_mode = "native host passthrough"
         cpu_label = cpu.model_name or cpu.vendor

--- a/src/osx_proxmox_next/defaults.py
+++ b/src/osx_proxmox_next/defaults.py
@@ -50,15 +50,15 @@ class CpuInfo:
     needs_emulated_cpu: bool  # True for AMD and Intel hybrid (12th gen+)
     needs_penryn: bool = False  # True for pre-Skylake Intel (Broadwell and older), excluding Xeon
     is_xeon: bool = False   # True when "Xeon" appears in model name (server chips, always use -cpu host)
-    xeon_hedt_model: str = ""  # Fixed QEMU -cpu model for Xeon E5/E7 v2-v4 HEDT chips (empty if not applicable)
+    xeon_hedt_model: str = ""  # Fixed QEMU -cpu model for multi-socket-capable Xeon HEDT/Scalable chips (empty if not applicable)
 
 
 def _classify_intel_cpu(family: int, model: int, model_name: str) -> tuple[bool, bool, bool]:
     """Classify an Intel CPU into (is_hybrid, is_xeon, is_legacy).
 
-    is_hybrid: Family 6 with P+E core topology (12th gen+) — needs emulated CPU.
-    is_xeon: Server/workstation chip — always uses -cpu host.
-    is_legacy: Pre-Skylake desktop (Broadwell and older) — needs Penryn mode.
+    is_hybrid: Family 6 with P+E core topology (12th gen+), needs emulated CPU.
+    is_xeon: Server/workstation chip, always uses -cpu host.
+    is_legacy: Pre-Skylake desktop (Broadwell and older), needs Penryn mode.
     """
     is_hybrid = (
         family == 6
@@ -83,24 +83,32 @@ def _classify_intel_cpu(family: int, model: int, model_name: str) -> tuple[bool,
 
 
 _XEON_HEDT_PATTERN = re.compile(r"Xeon.*E[57][ -]*\d+ *v([234])", re.IGNORECASE)
+_XEON_SCALABLE_PATTERN = re.compile(r"Xeon.*(?:Platinum|Gold|Silver|Bronze)[ -]*\d{4}", re.IGNORECASE)
 
 
 def _xeon_hedt_cpu_model(model_name: str) -> str:
-    """Return a fixed QEMU -cpu model for Xeon E5/E7 v2-v4 HEDT chips, or "".
+    """Return a fixed QEMU -cpu model for multi-socket-capable Xeon chips, or "".
 
-    Real HEDT parts (dual-socket/multi-die) leak their genuine multi-package
-    topology through -cpu host. Combined with a multi-socket-capable SMBIOS
-    (MacPro7,1), XNU's scheduler can livelock under heavy multithreaded I/O,
-    e.g. the macOS installer copy phase (CPU pegged at 100% while disk and
-    network progress both flatline). These exact overrides match the
-    known-working profile from github.com/mchiappinam/proxmox-macos.
+    Real HEDT and Scalable parts (dual-socket/multi-die) leak their genuine
+    multi-package topology through -cpu host. Combined with a multi-socket-
+    capable SMBIOS (MacPro7,1), XNU's scheduler can livelock under heavy
+    multithreaded I/O, e.g. the macOS installer copy phase (CPU pegged at
+    100% while disk and network progress both flatline).
+
+    E5/E7 v2-v4 HEDT overrides match the known-working profile from
+    github.com/mchiappinam/proxmox-macos. Xeon Scalable (Skylake-SP and
+    later: Platinum/Gold/Silver/Bronze) hits the identical livelock on
+    dual-socket boards; confirmed fix on Cascade Lake-SP is the same idea,
+    pin to a fixed non-host model instead of exposing genuine topology.
     """
     match = _XEON_HEDT_PATTERN.search(model_name)
-    if not match:
-        return ""
-    if match.group(1) == "2":
-        return "Haswell-noTSX,model=158,stepping=3"
-    return "Broadwell-noTSX,model=158"
+    if match:
+        if match.group(1) == "2":
+            return "Haswell-noTSX,model=158,stepping=3"
+        return "Broadwell-noTSX,model=158"
+    if _XEON_SCALABLE_PATTERN.search(model_name):
+        return "Skylake-Client-noTSX-IBRS"
+    return ""
 
 
 def detect_cpu_info() -> CpuInfo:
@@ -129,7 +137,7 @@ def detect_cpu_info() -> CpuInfo:
                 if len(parts) >= 2:
                     model_name = parts[1].strip()
             elif line.startswith("model"):
-                # "model\t\t: 183" — must come after "model name" check
+                # "model\t\t: 183" must come after "model name" check
                 parts = line.split(":")
                 if len(parts) >= 2 and parts[1].strip().isdigit():
                     model = int(parts[1].strip())

--- a/src/osx_proxmox_next/doctor.py
+++ b/src/osx_proxmox_next/doctor.py
@@ -170,11 +170,11 @@ def _check_boot_order(cfg: dict[str, str], vmid: int) -> DoctorCheck:
 
 
 def _check_cpu_hedt(cfg: dict[str, str], vmid: int) -> DoctorCheck | None:
-    """Flag real Xeon E5/E7 v2-v4 HEDT hosts still using -cpu host in args.
+    """Flag real multi-socket-capable Xeon hosts (HEDT or Scalable) still using -cpu host in args.
 
     Only meaningful when doctor runs on the same host the VM lives on
     (it reads the local CPU, not the VM's). Returns None when the host
-    isn't a detected HEDT Xeon, since the check doesn't apply.
+    isn't a detected HEDT/Scalable Xeon, since the check doesn't apply.
     """
     cpu_info = detect_cpu_info()
     if not cpu_info.xeon_hedt_model:
@@ -185,13 +185,13 @@ def _check_cpu_hedt(cfg: dict[str, str], vmid: int) -> DoctorCheck | None:
         return DoctorCheck(
             "cpu_hedt",
             Severity.OK,
-            f"HEDT Xeon detected, args uses -cpu {expected} (avoids XNU scheduler livelock)",
+            f"Multi-socket-capable Xeon detected, args uses -cpu {expected} (avoids XNU scheduler livelock)",
         )
     if "-cpu host" in args_val:
         return DoctorCheck(
             "cpu_hedt",
             Severity.FAIL,
-            "Host is a Xeon E5/E7 HEDT chip but this VM's args use -cpu host - "
+            "Host is a multi-socket-capable Xeon (HEDT or Scalable) but this VM's args use -cpu host - "
             "real multi-socket topology leaking through can livelock XNU's scheduler "
             "during install (CPU pegged at 100%, disk/network progress both flat zero)",
             fix=f"Recreate the VM so it picks up -cpu {expected} automatically, or manually replace -cpu host,... in the args line",

--- a/src/osx_proxmox_next/planner.py
+++ b/src/osx_proxmox_next/planner.py
@@ -32,8 +32,9 @@ def _cpu_args(cpu: CpuInfo, override: str = "") -> str:
     Intel hybrid CPUs (12th gen+) also need Cascadelake-Server because macOS
     hardware validation fails on P+E core topology with correct SMBIOS.
 
-    Non-hybrid Intel uses ``-cpu host`` for native passthrough, except real
-    Xeon E5/E7 v2-v4 HEDT chips, which get a fixed emulated model instead
+    Non-hybrid Intel uses ``-cpu host`` for native passthrough, except
+    multi-socket-capable Xeons (E5/E7 v2-v4 HEDT and Scalable
+    Platinum/Gold/Silver/Bronze), which get a fixed emulated model instead
     (see ``defaults._xeon_hedt_cpu_model``) to avoid an XNU scheduler
     livelock under heavy multithreaded I/O.
 

--- a/src/osx_proxmox_next/preflight.py
+++ b/src/osx_proxmox_next/preflight.py
@@ -7,7 +7,7 @@ import os
 from pathlib import Path
 import shutil
 
-from .defaults import detect_cpu_vendor
+from .defaults import detect_cpu_info, detect_cpu_vendor
 from .infrastructure import ProxmoxAdapter
 
 log = logging.getLogger(__name__)
@@ -138,11 +138,20 @@ def run_preflight() -> list[PreflightCheck]:
     checks.append(_check_initcall_blacklist())
 
     vendor = detect_cpu_vendor()
+    cpu_info = detect_cpu_info()
+    # Mirrors planner._cpu_args selection order so preflight reports the
+    # profile the plan will actually use.
+    if cpu_info.needs_emulated_cpu:
+        cpu_detail = "Cascadelake-Server emulation"
+    elif cpu_info.xeon_hedt_model:
+        cpu_detail = f"{cpu_info.xeon_hedt_model.split(',')[0]} (multi-socket Xeon profile)"
+    else:
+        cpu_detail = "native host passthrough"
     checks.append(
         PreflightCheck(
             name="CPU vendor",
             ok=True,
-            details=f"{vendor} - {'Cascadelake-Server emulation' if vendor == 'AMD' else 'native host passthrough'}",
+            details=f"{vendor} - {cpu_detail}",
         )
     )
     checks.append(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -132,6 +132,27 @@ def test_cli_plan_net_model_default_vmxnet3(monkeypatch, capsys):
     assert "vmxnet3" in captured.out
 
 
+def test_cli_plan_hedt_xeon_cpu_display(monkeypatch, capsys):
+    """Multi-socket-capable Xeon hosts show the pinned profile in plan output."""
+    from osx_proxmox_next.assets import AssetCheck
+    from osx_proxmox_next.defaults import CpuInfo
+    monkeypatch.setattr(
+        cli_module, "required_assets",
+        lambda cfg: [AssetCheck("OC", Path("/tmp/oc.iso"), True, ""), AssetCheck("Rec", Path("/tmp/rec.iso"), True, "")],
+    )
+    scalable_cpu = CpuInfo(
+        vendor="Intel", model_name="Intel(R) Xeon(R) Gold 6248 @ 2.50GHz",
+        family=6, model=85, needs_emulated_cpu=False, is_xeon=True,
+        xeon_hedt_model="Skylake-Client-noTSX-IBRS",
+    )
+    monkeypatch.setattr(cli_module, "detect_cpu_info", lambda: scalable_cpu)
+    rc = run_cli(_plan_args())
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "Skylake-Client-noTSX-IBRS (multi-socket Xeon profile)" in captured.out
+    assert "native host passthrough" not in captured.out
+
+
 def test_cli_preflight(monkeypatch):
     from osx_proxmox_next.preflight import PreflightCheck
     monkeypatch.setattr(
@@ -1225,7 +1246,7 @@ def test_cli_doctor_mixed_failures_and_warnings(monkeypatch, capsys) -> None:
 
 
 # ---------------------------------------------------------------------------
-# clone — apple_services message branch
+# clone - apple_services message branch
 # ---------------------------------------------------------------------------
 
 def test_cli_clone_execute_success_prints_apple_services(monkeypatch, tmp_path, capsys) -> None:

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -227,9 +227,18 @@ def test_xeon_hedt_cpu_model_v2():
 
 
 def test_xeon_hedt_cpu_model_non_hedt_xeon():
-    """Single-socket workstation Xeons (E3) and Scalable (Gold) are unaffected."""
+    """Single-socket workstation Xeons (E3) are unaffected."""
     assert _xeon_hedt_cpu_model("Intel(R) Xeon(R) CPU E3-1230 v5 @ 3.40GHz") == ""
-    assert _xeon_hedt_cpu_model("Intel(R) Xeon(R) Gold 6248 @ 2.50GHz") == ""
+
+
+def test_xeon_hedt_cpu_model_scalable():
+    """Xeon Scalable (Skylake-SP/Cascade Lake-SP: Platinum/Gold/Silver/Bronze)
+    hits the same multi-socket XNU scheduler livelock as E5/E7 HEDT and gets
+    a fixed emulated model instead of -cpu host."""
+    assert _xeon_hedt_cpu_model("Intel(R) Xeon(R) Gold 6248 @ 2.50GHz") == "Skylake-Client-noTSX-IBRS"
+    assert _xeon_hedt_cpu_model("Intel(R) Xeon(R) Platinum 8280 CPU @ 2.70GHz") == "Skylake-Client-noTSX-IBRS"
+    assert _xeon_hedt_cpu_model("Intel(R) Xeon(R) Silver 4214 CPU @ 2.20GHz") == "Skylake-Client-noTSX-IBRS"
+    assert _xeon_hedt_cpu_model("Intel(R) Xeon(R) Bronze 3204 CPU @ 1.90GHz") == "Skylake-Client-noTSX-IBRS"
 
 
 def test_xeon_hedt_cpu_model_non_xeon():

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -28,6 +28,36 @@ def test_preflight_has_expected_checks() -> None:
     assert len(checks) >= 15
 
 
+def _cpu_info(needs_emulated=False, hedt_model=""):
+    from osx_proxmox_next.defaults import CpuInfo
+    return CpuInfo(vendor="Intel", model_name="test", family=6, model=85,
+                   needs_emulated_cpu=needs_emulated, xeon_hedt_model=hedt_model)
+
+
+def _cpu_vendor_detail(checks):
+    return next(c for c in checks if c.name == "CPU vendor").details
+
+
+def test_preflight_cpu_detail_hedt_xeon(monkeypatch) -> None:
+    """Multi-socket-capable Xeon hosts report the pinned profile, not host passthrough."""
+    monkeypatch.setattr(preflight, "detect_cpu_info",
+                        lambda: _cpu_info(hedt_model="Skylake-Client-noTSX-IBRS"))
+    assert "Skylake-Client-noTSX-IBRS (multi-socket Xeon profile)" in \
+        _cpu_vendor_detail(run_preflight())
+
+
+def test_preflight_cpu_detail_emulated(monkeypatch) -> None:
+    """AMD and hybrid Intel hosts report Cascadelake-Server emulation."""
+    monkeypatch.setattr(preflight, "detect_cpu_info",
+                        lambda: _cpu_info(needs_emulated=True))
+    assert "Cascadelake-Server emulation" in _cpu_vendor_detail(run_preflight())
+
+
+def test_preflight_cpu_detail_host_passthrough(monkeypatch) -> None:
+    monkeypatch.setattr(preflight, "detect_cpu_info", lambda: _cpu_info())
+    assert "native host passthrough" in _cpu_vendor_detail(run_preflight())
+
+
 def test_find_binary_checks_common_system_paths(monkeypatch) -> None:
     monkeypatch.setattr(preflight.shutil, "which", lambda _cmd: None)
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
Fixes the AMD/HEDT boot livelock for Xeon Scalable hosts, which the earlier E5/E7-only detection missed.

## Changes
- fix(defaults): detect Xeon Scalable HEDT livelock, not just E5/E7
- fix(cli): report the pinned Xeon profile instead of host passthrough
- docs(readme): document the Xeon Scalable pinned CPU profile

## Testing
- [x] pytest: 929 passed, 97.74% coverage (gate: 95%)
