### PR TITLE
fix(recovery): never unlink stamp files, make stamping non-fatal

### DIFF
--- a/scripts/bash/osx-proxmox-next.sh
+++ b/scripts/bash/osx-proxmox-next.sh
@@ -1317,13 +1317,20 @@ fi
 safe_mount "${RLOOP}p1" "$RECOVERY_MNT" -t hfsplus -o rw
 # Write .contentDetails in CoreServices (matches Python planner)
 mkdir -p "$RECOVERY_MNT/System/Library/CoreServices"
-rm -f "$RECOVERY_MNT/System/Library/CoreServices/.contentDetails" 2>/dev/null
-printf '%s' "$MACOS_LABEL" > "$RECOVERY_MNT/System/Library/CoreServices/.contentDetails"
+# NEVER rm first: unlinking on the Linux hfsplus driver can leave a stale
+# catalog entry that makes any recreate fail with EEXIST. Overwrite through
+# the existing file; the label is cosmetic, so failure must not abort.
+printf '%s' "$MACOS_LABEL" > "$RECOVERY_MNT/System/Library/CoreServices/.contentDetails" 2>/dev/null \
+  || echo -e "  ${YW}WARN: .contentDetails stamp failed (cosmetic), continuing${CL}"
 # Copy InstallAssistant.icns → .VolumeIcon.icns (matches Python planner)
 ICON=$(find "$RECOVERY_MNT" -path '*/Install macOS*/Contents/Resources/InstallAssistant.icns' 2>/dev/null | head -1)
 if [ -n "$ICON" ]; then
-  rm -f "$RECOVERY_MNT/.VolumeIcon.icns"
-  cp "$ICON" "$RECOVERY_MNT/.VolumeIcon.icns"
+  # cat-overwrite instead of rm+cp: the Linux hfsplus driver sometimes
+  # refuses to unlink a .VolumeIcon.icns the BaseSystem already ships
+  # (Sonoma does); a cosmetic icon must never fail the install. Keep in
+  # sync with planner.py _recovery_steps.
+  cat "$ICON" > "$RECOVERY_MNT/.VolumeIcon.icns" 2>/dev/null \
+    || echo -e "  ${YW}WARN: volume icon copy failed (cosmetic), continuing${CL}"
 fi
 umount "$RECOVERY_MNT" 2>/dev/null || umount -l "$RECOVERY_MNT" 2>/dev/null || true
 losetup -d "$RLOOP" 2>/dev/null || true

--- a/src/osx_proxmox_next/planner.py
+++ b/src/osx_proxmox_next/planner.py
@@ -252,16 +252,22 @@ def _recovery_steps(
                 "{ [ -b \"${RLOOP}p1\" ] || { echo \"ERROR: ${RLOOP}p1 not found after partprobe. Hint: Try running the script again (slow storage)\"; false; }; } && "
                 "mount -t hfsplus -o rw ${RLOOP}p1 $OC_REC && "
                 "{ mountpoint -q $OC_REC || { echo \"ERROR: $OC_REC is not mounted. Hints: file ${RLOOP}p1; blkid ${RLOOP}p1; dmesg | tail -5\"; false; }; } && "
-                # Set custom name via .contentDetails in blessed directory
+                # Set custom name via .contentDetails in blessed directory.
+                # NEVER rm first: unlinking on the Linux hfsplus driver can
+                # leave a stale catalog entry that makes any recreate fail
+                # with EEXIST (hit on Sonoma's BaseSystem). Overwrite through
+                # the existing file instead, and treat failure as cosmetic:
+                # the label and icon only affect how the picker entry looks.
                 "mkdir -p $OC_REC/System/Library/CoreServices && "
-                "rm -f $OC_REC/System/Library/CoreServices/.contentDetails 2>/dev/null; "
-                f"printf '%s' '{macos_label}' > $OC_REC/System/Library/CoreServices/.contentDetails && "
+                f"{{ printf '%s' '{macos_label}' > $OC_REC/System/Library/CoreServices/.contentDetails 2>/dev/null "
+                "&& echo 'Recovery label stamped'; } "
+                "|| echo 'WARN: .contentDetails stamp failed (cosmetic), continuing'; "
                 # Copy macOS installer icon as .VolumeIcon.icns for boot picker
                 "ICON=$(find $OC_REC -path '*/Install macOS*/Contents/Resources/InstallAssistant.icns' 2>/dev/null | head -1) && "
                 "if [ -n \"$ICON\" ]; then "
-                "rm -f $OC_REC/.VolumeIcon.icns; "
-                "cp \"$ICON\" $OC_REC/.VolumeIcon.icns && "
-                "echo \"Volume icon set from $ICON\"; "
+                "{ cat \"$ICON\" > $OC_REC/.VolumeIcon.icns 2>/dev/null && "
+                "echo \"Volume icon set from $ICON\"; } "
+                "|| echo \"WARN: volume icon copy failed (cosmetic), continuing\"; "
                 "else echo \"No InstallAssistant.icns found, using default icon\"; fi && "
                 "{ umount $OC_REC || umount -l $OC_REC; } && losetup -d $RLOOP",
             ],

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -925,3 +925,24 @@ def test_build_post_install_plan_targets_correct_vmid() -> None:
     steps = build_post_install_plan(999)
     assert "qm set 999" in steps[1].command
     assert "qm set 999" in steps[3].command
+
+
+def test_recovery_icon_stamp_is_nonfatal():
+    """A cosmetic .VolumeIcon.icns copy failure must never fail the apply:
+    Sonoma's BaseSystem ships its own icon and the Linux hfsplus driver can
+    refuse to unlink it (cp then dies with File exists)."""
+    from osx_proxmox_next.domain import VmConfig
+    from osx_proxmox_next.planner import build_plan
+    config = VmConfig(vmid=908, name="macos-icon", macos="sonoma", cores=8,
+                      memory_mb=16384, disk_gb=128, bridge="vmbr0",
+                      storage="local-lvm")
+    steps = build_plan(config)
+    stamp = next(s for s in steps if "Stamp recovery" in s.title)
+    script = stamp.argv[-1]
+    assert 'cat "$ICON" >' in script
+    assert script.count("cosmetic") >= 2  # label AND icon are both non-fatal
+    # the old fatal forms must be gone, and no rm may precede the writes:
+    # unlinking on linux-hfsplus corrupts the catalog and recreates then fail
+    assert 'cp "$ICON" $OC_REC/.VolumeIcon.icns &&' not in script
+    assert "rm -f $OC_REC/.VolumeIcon.icns" not in script
+    assert "rm -f $OC_REC/System/Library/CoreServices/.contentDetails" not in script


### PR DESCRIPTION
## Summary
The recovery stamping step (picker label + volume icon) could fail the entire apply over cosmetic files. Sonoma's BaseSystem ships its own .VolumeIcon.icns and the Linux hfsplus driver refuses to unlink it; worse, a seemingly successful rm can leave a stale catalog entry so any recreate fails with EEXIST on the next run against the cached image.

## Changes
- Never rm the stamp files; write through the existing catalog entry with cat/printf
- Both stamps warn and continue on failure instead of aborting the install
- Mirrored in the bash installer, regression test asserts the fatal forms are gone

## Testing
- [x] Full suite: 930 passed, coverage 97.7%
- [x] Reproduced and verified on pve-tirsa: Sonoma apply failed twice on main's code, passed with this fix and installed through to Setup Assistant
