### PR TITLE
fix(bash): accept all Proxmox 8.x/9.x point releases

### DIFF
--- a/scripts/bash/osx-proxmox-next.sh
+++ b/scripts/bash/osx-proxmox-next.sh
@@ -231,23 +231,12 @@ function check_root() {
 pve_check() {
   local PVE_VER
   PVE_VER="$(pveversion | awk -F'/' '{print $2}' | awk -F'-' '{print $1}')"
-  if [[ "$PVE_VER" =~ ^8\.([0-9]+) ]]; then
-    local MINOR="${BASH_REMATCH[1]}"
-    if ((MINOR > 9)); then
-      msg_error "Requires Proxmox VE 8.0–8.9"
-      exit 1
-    fi
+  # Gate on the major version only. Proxmox minor releases stay compatible,
+  # and capping the minor broke every new point release (9.2 rejected, #123).
+  if [[ "$PVE_VER" =~ ^(8|9)\. ]]; then
     return 0
   fi
-  if [[ "$PVE_VER" =~ ^9\.([0-9]+) ]]; then
-    local MINOR="${BASH_REMATCH[1]}"
-    if ((MINOR > 1)); then
-      msg_error "Requires Proxmox VE 9.0–9.1"
-      exit 1
-    fi
-    return 0
-  fi
-  msg_error "Requires Proxmox VE 8.x or 9.x"
+  msg_error "Requires Proxmox VE 8.x or 9.x (detected: ${PVE_VER:-unknown})"
   exit 1
 }
 

--- a/tests/test_script_renderer.py
+++ b/tests/test_script_renderer.py
@@ -546,3 +546,44 @@ def test_plist_patch_script_registers_restrictevents_kext() -> None:
 def test_plist_patch_script_restrictevents_entry_guarded_by_kext_dir() -> None:
     script = _plist_patch_script()
     assert 'os.path.isdir(oc_dest+"/EFI/OC/Kexts/RestrictEvents.kext")' in script
+
+
+@pytest.mark.parametrize("version,accepted", [
+    ("8.0.4", True),
+    ("8.4.1", True),
+    ("9.0.3", True),
+    ("9.1.1", True),
+    ("9.2.4", True),   # regression: minor-version cap rejected 9.2 (#123)
+    ("9.7.0", True),
+    ("10.0.1", False),
+    ("7.4.1", False),
+    ("", False),
+])
+def test_bash_pve_check_gates_on_major_version_only(tmp_path: Path, version: str,
+                                                    accepted: bool) -> None:
+    """Execute the real pve_check with a stubbed pveversion.
+
+    Proxmox minor releases stay compatible, so only the major version may be
+    gated; capping the minor broke every new point release (9.2, issue #123).
+    """
+    import re as _re
+    import subprocess
+
+    script = (Path(__file__).resolve().parent.parent
+              / "scripts/bash/osx-proxmox-next.sh").read_text()
+    m = _re.search(r"pve_check\(\) \{.*?\n\}", script, _re.S)
+    assert m, "pve_check not found in bash script"
+    harness = tmp_path / "harness.sh"
+    harness.write_text(
+        "#!/usr/bin/env bash\n"
+        f'pveversion() {{ echo "pve-manager/{version}/abcdef"; }}\n'
+        'msg_error() { echo "ERR: $1"; }\n'
+        + m.group(0) + "\n"
+        "pve_check && echo ACCEPTED\n"
+    )
+    result = subprocess.run(["bash", str(harness)], capture_output=True, text=True)
+    if accepted:
+        assert "ACCEPTED" in result.stdout, result.stdout + result.stderr
+    else:
+        assert "ACCEPTED" not in result.stdout
+        assert result.returncode == 1


### PR DESCRIPTION
## Summary
The bash installer's pve_check capped the minor version (8.0-8.9, 9.0-9.1), so every new Proxmox point release got rejected. 9.2.4 failed before the wizard even started (#123).

## Changes
- Gate on the major version only: any 8.x or 9.x passes, everything else is rejected with the detected version shown
- Regression test executes the real pve_check against stubbed pveversion outputs from 7.4 to 10.0

## Testing
- [x] Full suite: 939 passed, coverage 97.7%
- [x] Verified against the real pveversion output on a PVE 9.2.5 node

Closes #123
