### PR TITLE
feat(wizard): block VM memory beyond the host's free RAM

### DIFF
--- a/scripts/bash/osx-proxmox-next.sh
+++ b/scripts/bash/osx-proxmox-next.sh
@@ -404,7 +404,50 @@ function detect_cpu_cores() {
   round_down_pow2 "$half"
 }
 
-# ── Detect smart memory default (half host, clamp 4096–32768) ──
+# Kept free for the Proxmox host itself (pve daemons, ZFS ARC headroom, ssh).
+# The VM runs with balloon=0, so its full allocation is pinned at qm start.
+HOST_RAM_RESERVE_MB=1024
+
+# ── Host MemAvailable in MiB (0 = unknown) ──
+function detect_available_memory_mb() {
+  local kb
+  kb=$(awk '/^MemAvailable:/{print $2}' /proc/meminfo 2>/dev/null || echo 0)
+  if ! [[ "$kb" =~ ^[0-9]+$ ]] || [ "$kb" -le 0 ]; then
+    echo 0
+    return
+  fi
+  echo $((kb / 1024))
+}
+
+# ── Largest VM allocation the host can take right now (0 = unknown) ──
+function max_vm_memory_mb() {
+  local avail
+  avail=$(detect_available_memory_mb)
+  if [ "$avail" -le 0 ]; then
+    echo 0
+  elif [ "$avail" -le "$HOST_RAM_RESERVE_MB" ]; then
+    echo 0
+  else
+    echo $((avail - HOST_RAM_RESERVE_MB))
+  fi
+}
+
+# ── Block when the requested RAM exceeds what the host has free ──
+# balloon=0 pins the whole allocation at qm start, so more than the host's
+# free RAM either fails the start or OOM-kills mid-install. Keep in sync
+# with forms/form_handler.py validate_form_values.
+function require_vm_memory_fits() {
+  local requested="$1" limit
+  limit=$(max_vm_memory_mb)
+  if [ "$limit" -gt 0 ] && [ "$requested" -gt "$limit" ]; then
+    msg_error "Not enough free RAM on this host for a ${requested} MiB VM"
+    echo -e "  Host has only ${limit} MiB free for a VM (MemAvailable minus ${HOST_RAM_RESERVE_MB} MiB host reserve)."
+    echo -e "  Lower the VM memory or free up host RAM, then run the script again."
+    exit 1
+  fi
+}
+
+# ── Detect smart memory default (half host, clamp 4096–32768, fit free RAM) ──
 function detect_memory_mb() {
   local mem_kb
   mem_kb=$(awk '/^MemTotal:/{print $2}' /proc/meminfo 2>/dev/null || echo 0)
@@ -414,6 +457,12 @@ function detect_memory_mb() {
   fi
   local mem_mb=$((mem_kb / 1024))
   local half=$((mem_mb / 2))
+  # Never suggest more than what is actually free right now (balloon=0).
+  local limit
+  limit=$(max_vm_memory_mb)
+  if [ "$limit" -gt 0 ] && [ "$half" -gt "$limit" ]; then
+    half="$limit"
+  fi
   [ "$half" -lt 4096 ] && half=4096
   [ "$half" -gt 32768 ] && half=32768
   echo "$half"
@@ -964,9 +1013,12 @@ function advanced_settings() {
     exit-script
   fi
 
-  local default_ram
+  local default_ram ram_limit ram_hint
   default_ram=$(detect_memory_mb)
-  if RAM_SIZE=$(whiptail --backtitle "OSX Proxmox Next" --inputbox "Allocate RAM in MiB (minimum 4096)" 8 58 "$default_ram" --title "RAM" --cancel-button Exit-Script 3>&1 1>&2 2>&3); then
+  ram_limit=$(max_vm_memory_mb)
+  ram_hint="Allocate RAM in MiB (minimum 4096)"
+  [ "$ram_limit" -gt 0 ] && ram_hint="Allocate RAM in MiB (minimum 4096, host has ${ram_limit} free)"
+  if RAM_SIZE=$(whiptail --backtitle "OSX Proxmox Next" --inputbox "$ram_hint" 8 58 "$default_ram" --title "RAM" --cancel-button Exit-Script 3>&1 1>&2 2>&3); then
     if [ -z "$RAM_SIZE" ]; then
       RAM_SIZE="$default_ram"
     fi
@@ -1074,6 +1126,10 @@ pve_check
 ssh_check
 check_dependencies
 start_script
+
+# Both settings paths have set RAM_SIZE by now; refuse to continue when the
+# host cannot actually back that allocation (balloon=0 pins it at qm start).
+require_vm_memory_fits "$RAM_SIZE"
 
 # ── Storage selection ──
 msg_info "Validating Storage"

--- a/src/osx_proxmox_next/_wizard_mixin.py
+++ b/src/osx_proxmox_next/_wizard_mixin.py
@@ -14,6 +14,7 @@ from .defaults import (
     detect_cpu_cores,
     detect_cpu_info,
     detect_memory_mb,
+    max_vm_memory_mb,
 )
 from .domain import SUPPORTED_MACOS, VmConfig
 from .forms import validate_form_values, build_vm_config_from_values
@@ -87,7 +88,7 @@ class WizardStepsMixin:
 
     def _validate_form(self, quiet: bool = False) -> bool:
         values = self._read_form_values()  # type: ignore[attr-defined]
-        errors = validate_form_values(values)
+        errors = validate_form_values(values, host_memory_limit_mb=max_vm_memory_mb())
         for field_id in ("vmid", "name", "memory", "disk", "bridge", "storage_input"):
             widget = self.query_one(f"#{field_id}", Input)
             (widget.add_class if field_id in errors else widget.remove_class)("invalid")

--- a/src/osx_proxmox_next/defaults.py
+++ b/src/osx_proxmox_next/defaults.py
@@ -191,22 +191,50 @@ def detect_cpu_cores() -> int:
     return _round_down_power_of_2(half)
 
 
-def detect_memory_mb() -> int:
-    mem_total_kb = 0
+def _meminfo_mb(field: str) -> int:
+    """Read one /proc/meminfo field in MB; 0 when absent or unreadable."""
     meminfo = Path("/proc/meminfo")
-    if meminfo.exists():
-        for line in meminfo.read_text(encoding="utf-8", errors="ignore").splitlines():
-            if line.startswith("MemTotal:"):
-                parts = line.split()
-                if len(parts) >= 2 and parts[1].isdigit():
-                    mem_total_kb = int(parts[1])
-                break
-    if mem_total_kb <= 0:
+    if not meminfo.exists():
+        return 0
+    for line in meminfo.read_text(encoding="utf-8", errors="ignore").splitlines():
+        if line.startswith(field + ":"):
+            parts = line.split()
+            if len(parts) >= 2 and parts[1].isdigit():
+                return int(parts[1]) // 1024
+            break
+    return 0
+
+
+# Kept free for the Proxmox host itself (pve daemons, ZFS ARC headroom, ssh).
+# The VM runs with balloon=0, so its full allocation is pinned at qm start.
+HOST_RAM_RESERVE_MB = 1024
+
+
+def detect_available_memory_mb() -> int:
+    """Host MemAvailable in MB; 0 when unknown (non-Linux or old kernel)."""
+    return _meminfo_mb("MemAvailable")
+
+
+def max_vm_memory_mb() -> int:
+    """Largest VM allocation the host can take right now (0 = unknown)."""
+    avail = detect_available_memory_mb()
+    if avail <= 0:
+        return 0
+    return max(0, avail - HOST_RAM_RESERVE_MB)
+
+
+def detect_memory_mb() -> int:
+    mem_total_mb = _meminfo_mb("MemTotal")
+    if mem_total_mb <= 0:
         return 8192
 
-    mem_total_mb = mem_total_kb // 1024
-    # Default to half of host memory with sane bounds.
-    return max(_MIN_MEMORY_MB, min(_MAX_MEMORY_MB, mem_total_mb // 2))
+    # Default to half of host memory, but never suggest more than what is
+    # actually free right now (the allocation is pinned, balloon=0).
+    default = mem_total_mb // 2
+    limit = max_vm_memory_mb()
+    if limit > 0:
+        default = min(default, limit)
+    return max(_MIN_MEMORY_MB, min(_MAX_MEMORY_MB, default))
 
 
 DEFAULT_ISO_DIR = "/var/lib/vz/template/iso"

--- a/src/osx_proxmox_next/forms/form_handler.py
+++ b/src/osx_proxmox_next/forms/form_handler.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 
-from ..defaults import DEFAULT_BRIDGE, DEFAULT_ISO_DIR, DEFAULT_MEMORY_MB, DEFAULT_STORAGE
+from ..defaults import (
+    DEFAULT_BRIDGE,
+    DEFAULT_ISO_DIR,
+    DEFAULT_MEMORY_MB,
+    DEFAULT_STORAGE,
+    HOST_RAM_RESERVE_MB,
+)
 from ..domain import MIN_DISK_GB, MIN_MEMORY_MB, MIN_VMID, MAX_VMID, VmConfig
 from ..smbios import SmbiosIdentity
 
@@ -34,10 +40,15 @@ class FormValues:
     smbios: SmbiosIdentity | None = None
 
 
-def validate_form_values(values: FormValues) -> dict[str, str]:
+def validate_form_values(values: FormValues,
+                         host_memory_limit_mb: int | None = None) -> dict[str, str]:
     """Return a dict of field_id → error message for invalid fields.
 
     Returns an empty dict when all fields are valid.
+
+    *host_memory_limit_mb* is the largest allocation the host can take right
+    now (defaults.max_vm_memory_mb()). None or 0 skips that check, so pure
+    unit tests and non-Linux hosts are unaffected.
     """
     errors: dict[str, str] = {}
 
@@ -55,6 +66,14 @@ def validate_form_values(values: FormValues) -> dict[str, str]:
         mem_val = int(values.memory)
         if mem_val < MIN_MEMORY_MB:
             raise ValueError
+        # balloon=0 pins the whole allocation at qm start, so more than the
+        # host's free RAM either fails the start or OOM-kills mid-install.
+        if host_memory_limit_mb and mem_val > host_memory_limit_mb:
+            errors["memory"] = (
+                f"Host has only {host_memory_limit_mb} MB free for a VM "
+                f"(MemAvailable minus {HOST_RAM_RESERVE_MB} MB host reserve). "
+                f"Lower the VM memory."
+            )
     except ValueError:
         errors["memory"] = f"Memory must be >= {MIN_MEMORY_MB} MB."
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,18 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
+def _no_host_memory_limit(monkeypatch):
+    """Pin the host-RAM headroom check to 'unknown' for all tests.
+
+    max_vm_memory_mb() reads the live /proc/meminfo, so on a Linux CI runner
+    (or a loaded dev box) form validation would depend on how much RAM the
+    machine happens to have free. Tests that exercise the check re-patch it
+    with an explicit value."""
+    monkeypatch.setattr("osx_proxmox_next.defaults.max_vm_memory_mb", lambda: 0)
+    monkeypatch.setattr("osx_proxmox_next._wizard_mixin.max_vm_memory_mb", lambda: 0)
+
+
+@pytest.fixture(autouse=True)
 def _reset_event_loop_policy():
     """Reset the asyncio event loop policy before and after each test."""
     asyncio.set_event_loop_policy(None)

--- a/tests/test_app_wizard.py
+++ b/tests/test_app_wizard.py
@@ -548,6 +548,26 @@ def test_validate_form_all_invalid() -> None:
     asyncio.run(_run())
 
 
+def test_validate_form_blocks_when_memory_exceeds_host_ram(monkeypatch) -> None:
+    """A VM bigger than the host's free RAM must flag the memory field and
+    keep Next disabled (balloon=0 pins the whole allocation at qm start)."""
+    async def _run() -> None:
+        monkeypatch.setattr("osx_proxmox_next._wizard_mixin.max_vm_memory_mb",
+                            lambda: 6000)
+        app = NextApp()
+        async with app.run_test(size=(120, 50)) as pilot:
+            await pilot.pause()
+            await _advance_to_step(pilot, app, 4)
+            app.query_one("#memory", Input).value = "16384"
+            result = app._validate_form(quiet=True)
+            assert result is False
+            assert app.query_one("#memory", Input).has_class("invalid")
+            errors_text = str(app.query_one("#form_errors", Static).content)
+            assert "6000 MB free" in errors_text
+
+    asyncio.run(_run())
+
+
 def test_validate_form_valid() -> None:
     async def _run() -> None:
         app = NextApp()

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -593,3 +593,52 @@ def test_detect_iso_storage_resolves_path(monkeypatch):
     dirs = detect_iso_storage()
     assert "/mnt/pve/nas-iso/template/iso" in dirs
     assert DEFAULT_ISO_DIR in dirs
+
+
+def test_detect_available_memory_mb(monkeypatch, tmp_path):
+    from osx_proxmox_next.defaults import detect_available_memory_mb
+    fake = tmp_path / "meminfo"
+    fake.write_text("MemTotal:       32768000 kB\nMemAvailable:   8192000 kB\n")
+    monkeypatch.setattr("osx_proxmox_next.defaults.Path",
+                        lambda p: fake if p == "/proc/meminfo" else Path(p))
+    assert detect_available_memory_mb() == 8000
+
+
+def test_detect_available_memory_unknown(monkeypatch):
+    from osx_proxmox_next.defaults import detect_available_memory_mb
+    monkeypatch.setattr("osx_proxmox_next.defaults.Path",
+                        lambda p: Path("/nonexistent/meminfo"))
+    assert detect_available_memory_mb() == 0
+
+
+def test_max_vm_memory_subtracts_host_reserve(monkeypatch, tmp_path):
+    import osx_proxmox_next.defaults as d
+    fake = tmp_path / "meminfo"
+    fake.write_text("MemAvailable:   8192000 kB\n")
+    monkeypatch.setattr("osx_proxmox_next.defaults.Path",
+                        lambda p: fake if p == "/proc/meminfo" else Path(p))
+    # conftest pins max_vm_memory_mb to 0; call the real one via the module dict
+    monkeypatch.undo()
+    monkeypatch.setattr("osx_proxmox_next.defaults.Path",
+                        lambda p: fake if p == "/proc/meminfo" else Path(p))
+    assert d.max_vm_memory_mb() == 8000 - d.HOST_RAM_RESERVE_MB
+
+
+def test_max_vm_memory_unknown_when_no_meminfo(monkeypatch):
+    import osx_proxmox_next.defaults as d
+    monkeypatch.undo()
+    monkeypatch.setattr("osx_proxmox_next.defaults.Path",
+                        lambda p: Path("/nonexistent/meminfo"))
+    assert d.max_vm_memory_mb() == 0
+
+
+def test_detect_memory_default_clamped_to_available(monkeypatch, tmp_path):
+    """Half of total would be 16000 MB, but only 6 GB is actually free:
+    the suggested default must fit what the host can pin (balloon=0)."""
+    import osx_proxmox_next.defaults as d
+    monkeypatch.undo()
+    fake = tmp_path / "meminfo"
+    fake.write_text("MemTotal:       32768000 kB\nMemAvailable:   6144000 kB\n")
+    monkeypatch.setattr("osx_proxmox_next.defaults.Path",
+                        lambda p: fake if p == "/proc/meminfo" else Path(p))
+    assert d.detect_memory_mb() == 6000 - d.HOST_RAM_RESERVE_MB

--- a/tests/test_form_handler.py
+++ b/tests/test_form_handler.py
@@ -246,3 +246,35 @@ def test_build_vm_config_from_values_no_apple_services_vmgenid_empty() -> None:
     values = _valid_values(apple_services=False, custom_vmgenid="some-id")
     result = build_vm_config_from_values(values)
     assert result.vmgenid == ""
+
+
+# ---------------------------------------------------------------------------
+# validate_form_values - host RAM headroom
+# ---------------------------------------------------------------------------
+
+
+def test_memory_over_host_limit_is_rejected() -> None:
+    errors = validate_form_values(_valid_values(memory="16384"),
+                                  host_memory_limit_mb=8000)
+    assert "memory" in errors
+    assert "8000 MB free" in errors["memory"]
+
+
+def test_memory_at_host_limit_is_accepted() -> None:
+    errors = validate_form_values(_valid_values(memory="8000"),
+                                  host_memory_limit_mb=8000)
+    assert errors == {}
+
+
+def test_memory_limit_unknown_skips_host_check() -> None:
+    for limit in (None, 0):
+        errors = validate_form_values(_valid_values(memory="16384"),
+                                      host_memory_limit_mb=limit)
+        assert errors == {}
+
+
+def test_memory_below_minimum_beats_host_limit_message() -> None:
+    errors = validate_form_values(_valid_values(memory="100"),
+                                  host_memory_limit_mb=8000)
+    assert "memory" in errors
+    assert ">= 4096" in errors["memory"]


### PR DESCRIPTION
## Summary
The VM runs with balloon=0, so its full allocation is pinned at qm start. Asking for more RAM than the host has free either fails the start or OOM-kills the install midway. Both installers now check MemAvailable and refuse to continue when the requested memory doesn't fit, keeping 1 GB reserved for the host itself.

## Changes
- TUI: the memory field is flagged with the free amount in the message and Next stays blocked until it fits
- bash: default and advanced paths both checked after settings; the RAM prompt shows how much the host has free
- The suggested default (half of total) is additionally clamped to what is actually free
- Hosts where MemAvailable is unreadable skip the check unchanged

## Testing
- [x] Full suite: 951 passed, coverage 97.7% (host lookup pinned in tests so CI runner RAM can't skew results)
- [x] Verified live on a 192 GB node: 86 GB free detected, oversized request blocked, fitting request accepted
