### PR TITLE
feat(tui): add optional VLAN tag to VM network config

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Same VM creation logic (OpenCore + osrecovery + SMBIOS), whiptail menus, no venv
 | **1️⃣ Preflight** | Auto-detects CPU vendor (Intel/AMD), checks host readiness |
 | **2️⃣ Choose OS** | Pick macOS version (Ventura, Sonoma, Sequoia, Tahoe) - SMBIOS auto-generated |
 | **3️⃣ Storage** | Select storage target from auto-detected Proxmox storage pools |
-| **4️⃣ Config** | Review/edit VM settings (VMID, cores, memory, disk) with auto-filled defaults |
+| **4️⃣ Config** | Review/edit VM settings (VMID, cores, memory, disk, bridge, optional VLAN tag) with auto-filled defaults |
 | **5️⃣ Dry Run** | Auto-downloads missing assets, then previews every `qm` command |
 | **6️⃣ Install** | Creates the VM, builds OpenCore, imports disks, and starts the VM |
 
@@ -260,6 +260,12 @@ osx-next-cli apply --execute \
   --vmid 910 --name macos-sequoia --macos sequoia \
   --cores 8 --memory 16384 --disk 128 \
   --bridge vmbr0 --storage local-lvm
+
+# Put the VM on a tagged VLAN (blank/omitted = untagged)
+osx-next-cli apply --execute \
+  --vmid 910 --name macos-sequoia --macos sequoia \
+  --cores 8 --memory 16384 --disk 128 \
+  --bridge vmbr0 --vlan 20 --storage local-lvm
 
 # Enable verbose kernel log (shows text instead of Apple logo during boot)
 osx-next-cli apply --execute --verbose-boot \

--- a/src/osx_proxmox_next/_wizard_mixin.py
+++ b/src/osx_proxmox_next/_wizard_mixin.py
@@ -54,6 +54,7 @@ class WizardStepsMixin:
         self._set_input_value("#memory", str(detect_memory_mb()))  # type: ignore[attr-defined]
         self._set_input_value("#disk", str(default_disk_gb(macos)))  # type: ignore[attr-defined]
         self._set_input_value("#bridge", DEFAULT_BRIDGE)  # type: ignore[attr-defined]
+        self._set_input_value("#vlan", "")  # type: ignore[attr-defined]
         self._set_input_value(  # type: ignore[attr-defined]
             "#storage_input",
             storage_fallback or self.state.selected_storage or DEFAULT_STORAGE,  # type: ignore[attr-defined]
@@ -89,7 +90,7 @@ class WizardStepsMixin:
     def _validate_form(self, quiet: bool = False) -> bool:
         values = self._read_form_values()  # type: ignore[attr-defined]
         errors = validate_form_values(values, host_memory_limit_mb=max_vm_memory_mb())
-        for field_id in ("vmid", "name", "memory", "disk", "bridge", "storage_input"):
+        for field_id in ("vmid", "name", "memory", "disk", "bridge", "vlan", "storage_input"):
             widget = self.query_one(f"#{field_id}", Input)
             (widget.add_class if field_id in errors else widget.remove_class)("invalid")
         self.state.form_errors = errors  # type: ignore[attr-defined]
@@ -116,6 +117,7 @@ class WizardStepsMixin:
             memory=self.query_one("#memory", Input).value.strip(),
             disk=self.query_one("#disk", Input).value.strip(),
             bridge=self.query_one("#bridge", Input).value.strip(),
+            vlan=self.query_one("#vlan", Input).value.strip(),
             storage=self.query_one("#storage_input", Input).value.strip(),
             iso_dir=self.query_one("#iso_dir", Input).value.strip(),
             installer_path=self.query_one("#installer_path", Input).value.strip(),

--- a/src/osx_proxmox_next/cli.py
+++ b/src/osx_proxmox_next/cli.py
@@ -40,6 +40,7 @@ def _config_from_args(args: argparse.Namespace) -> VmConfig:
         memory_mb=args.memory,
         disk_gb=args.disk,
         bridge=args.bridge,
+        vlan=getattr(args, "vlan", 0) or 0,
         storage=args.storage,
         installer_path=args.installer_path or "",
         smbios_serial=args.smbios_serial or "",
@@ -98,6 +99,8 @@ def _build_common_parser() -> argparse.ArgumentParser:
     common.add_argument("--memory", type=int, required=True)
     common.add_argument("--disk", type=int, required=True)
     common.add_argument("--bridge", type=str, required=True)
+    common.add_argument("--vlan", type=int, default=0,
+                        help="Optional VLAN tag for net0 (1-4094; 0/omitted = untagged)")
     common.add_argument("--storage", type=str, required=True)
     common.add_argument("--installer-path", type=str, default="")
     common.add_argument("--smbios-serial", type=str, default="")

--- a/src/osx_proxmox_next/domain.py
+++ b/src/osx_proxmox_next/domain.py
@@ -45,6 +45,7 @@ class VmConfig:
     iso_dir: str = ""
     cpu_model: str = ""
     net_model: str = "vmxnet3"
+    vlan: int = 0  # 0 = untagged
 
 
 @dataclass
@@ -125,6 +126,8 @@ def validate_config(config: VmConfig) -> list[str]:
         issues.append(f"At least {MIN_DISK_GB} GB disk is required.")
     if not re.fullmatch(r"vmbr[0-9]+", config.bridge):
         issues.append("Bridge must match vmbr<N> (e.g. vmbr0).")
+    if config.vlan and not (1 <= config.vlan <= 4094):
+        issues.append("VLAN tag must be between 1 and 4094 (or 0 for untagged).")
     if config.name and not re.fullmatch(r"[a-zA-Z0-9]([a-zA-Z0-9.\-]*[a-zA-Z0-9])?", config.name):
         issues.append("VM name must start with alphanumeric and contain only [a-zA-Z0-9.-].")
     if config.installer_path and not re.fullmatch(r"[a-zA-Z0-9/._\-]+", config.installer_path):

--- a/src/osx_proxmox_next/forms/form_handler.py
+++ b/src/osx_proxmox_next/forms/form_handler.py
@@ -26,6 +26,7 @@ class FormValues:
     memory: str = str(DEFAULT_MEMORY_MB)
     disk: str = "128"
     bridge: str = DEFAULT_BRIDGE
+    vlan: str = ""
     storage: str = DEFAULT_STORAGE
     iso_dir: str = DEFAULT_ISO_DIR
     installer_path: str = ""
@@ -87,6 +88,14 @@ def validate_form_values(values: FormValues,
     if not re.fullmatch(r"vmbr[0-9]+", values.bridge):
         errors["bridge"] = "Bridge must match vmbr<N> (e.g. vmbr0)."
 
+    if values.vlan:
+        try:
+            vlan_val = int(values.vlan)
+            if vlan_val < 1 or vlan_val > 4094:
+                raise ValueError
+        except ValueError:
+            errors["vlan"] = "VLAN must be 1-4094 (or blank for untagged)."
+
     if not values.storage:
         errors["storage_input"] = "Storage target is required."
 
@@ -103,6 +112,7 @@ def build_vm_config_from_values(values: FormValues) -> VmConfig | None:
         cores = int(values.cores or "8")
         memory_mb = int(values.memory or DEFAULT_MEMORY_MB)
         disk_gb = int(values.disk or "128")
+        vlan = int(values.vlan) if values.vlan.strip() else 0
     except ValueError:
         return None
 
@@ -115,6 +125,7 @@ def build_vm_config_from_values(values: FormValues) -> VmConfig | None:
         memory_mb=memory_mb,
         disk_gb=disk_gb,
         bridge=values.bridge or DEFAULT_BRIDGE,
+        vlan=vlan,
         storage=values.storage or DEFAULT_STORAGE,
         installer_path=values.installer_path,
         iso_dir=values.iso_dir or DEFAULT_ISO_DIR,

--- a/src/osx_proxmox_next/planner.py
+++ b/src/osx_proxmox_next/planner.py
@@ -124,6 +124,13 @@ def build_plan(config: VmConfig) -> list[PlanStep]:
     return steps
 
 
+def _net0_value(config: VmConfig, macaddr: str = "") -> str:
+    """Build the qm net0 value, honoring the optional VLAN tag."""
+    mac = f",macaddr={macaddr}" if macaddr else ""
+    tag = f",tag={config.vlan}" if config.vlan else ""
+    return f"{config.net_model},bridge={config.bridge}{mac}{tag},firewall=0"
+
+
 def _network_steps(config: VmConfig, vmid: str, cpu_flag: str) -> list[PlanStep]:
     """VM shell creation with network and CPU config."""
     return [
@@ -141,7 +148,7 @@ def _network_steps(config: VmConfig, vmid: str, cpu_flag: str) -> list[PlanStep]
                 "--cpu", "host",
                 "--balloon", "0",
                 "--agent", "enabled=1",
-                "--net0", f"{config.net_model},bridge={config.bridge},firewall=0",
+                "--net0", _net0_value(config),
             ],
         ),
         PlanStep(
@@ -440,7 +447,7 @@ def _apple_services_steps(config: VmConfig, vmid: str) -> list[PlanStep]:
         ),
         PlanStep(
             title="Configure static MAC for Apple services",
-            argv=["qm", "set", vmid, "--net0", f"{config.net_model},bridge={config.bridge},macaddr={config.static_mac},firewall=0"],
+            argv=["qm", "set", vmid, "--net0", _net0_value(config, config.static_mac)],
         ),
     ]
 
@@ -567,15 +574,17 @@ def build_edit_plan(
 # ── VM Clone ────────────────────────────────────────────────────────
 
 
-def _parse_net0(current_net0: str | None) -> tuple[str, str]:
-    """Extract bridge and NIC model from a raw Proxmox VM config dump.
+def _parse_net0(current_net0: str | None) -> tuple[str, str, str]:
+    """Extract bridge, NIC model, and VLAN tag from a raw Proxmox VM config dump.
 
-    Returns ``(bridge, net_model)`` with safe defaults when not found.
+    Returns ``(bridge, net_model, vlan)`` with safe defaults when not found;
+    *vlan* is "" when the NIC is untagged.
     """
     bridge = "vmbr0"
     net_model = "vmxnet3"
+    vlan = ""
     if not current_net0:
-        return bridge, net_model
+        return bridge, net_model, vlan
     for line in current_net0.splitlines():
         if not line.startswith("net0:"):
             continue
@@ -589,8 +598,10 @@ def _parse_net0(current_net0: str | None) -> tuple[str, str]:
         for part in parts[1:]:
             if part.startswith("bridge="):
                 bridge = part.split("=", 1)[1]
+            elif part.startswith("tag="):
+                vlan = part.split("=", 1)[1]
         break
-    return bridge, net_model
+    return bridge, net_model, vlan
 
 
 def build_clone_plan(
@@ -644,13 +655,14 @@ def build_clone_plan(
             title="Regenerate vmgenid (Apple services isolation)",
             argv=["qm", "set", dst, "--vmgenid", vmgenid],
         ))
-        bridge, net_model = _parse_net0(current_net0)
+        bridge, net_model, vlan = _parse_net0(current_net0)
         fresh_mac = generate_mac()
+        tag = f",tag={vlan}" if vlan else ""
         steps.append(PlanStep(
             title="Assign fresh static MAC (Apple services isolation)",
             argv=[
                 "qm", "set", dst,
-                "--net0", f"{net_model},bridge={bridge},macaddr={fresh_mac},firewall=0",
+                "--net0", f"{net_model},bridge={bridge},macaddr={fresh_mac}{tag},firewall=0",
             ],
         ))
 

--- a/src/osx_proxmox_next/screens/step_screens.py
+++ b/src/osx_proxmox_next/screens/step_screens.py
@@ -120,6 +120,8 @@ def _compose_step4_vm_fields() -> ComposeResult:
         yield Input(value="128", id="disk")
         yield Static("Bridge", classes="label")
         yield Input(value=DEFAULT_BRIDGE, id="bridge")
+        yield Static("VLAN Tag (optional)", classes="label")
+        yield Input(value="", id="vlan", placeholder="Untagged")
         yield Static("Storage", classes="label")
         yield Input(value=DEFAULT_STORAGE, id="storage_input")
         yield Static("ISO Storage", classes="label")

--- a/src/osx_proxmox_next/screens/summary_screen.py
+++ b/src/osx_proxmox_next/screens/summary_screen.py
@@ -26,7 +26,8 @@ def build_config_summary_text(
         f"Target: {meta.get('label', config.macos)} ({meta.get('channel', '?')})",
         f"VM: {config.vmid} / {config.name}",
         f"CPU: {cpu_label} - {config.cores} cores | Memory: {config.memory_mb} MB | Disk: {config.disk_gb} GB",
-        f"Storage: {config.storage} | Bridge: {config.bridge}",
+        f"Storage: {config.storage} | Bridge: {config.bridge}"
+        + (f" | VLAN: {config.vlan}" if config.vlan else ""),
     ]
     if config.installer_path:
         lines.append(f"Installer: {config.installer_path}")

--- a/tests/test_clone_planner.py
+++ b/tests/test_clone_planner.py
@@ -11,47 +11,47 @@ from osx_proxmox_next.planner import _parse_net0, build_clone_plan
 
 
 def test_parse_net0_returns_defaults_when_none():
-    bridge, model = _parse_net0(None)
+    bridge, model, _vlan = _parse_net0(None)
     assert bridge == "vmbr0"
     assert model == "vmxnet3"
 
 
 def test_parse_net0_returns_defaults_when_empty():
-    bridge, model = _parse_net0("")
+    bridge, model, _vlan = _parse_net0("")
     assert bridge == "vmbr0"
     assert model == "vmxnet3"
 
 
 def test_parse_net0_with_static_mac():
     raw = "name: macos-test\nnet0: vmxnet3=AA:BB:CC:DD:EE:FF,bridge=vmbr1,firewall=0\n"
-    bridge, model = _parse_net0(raw)
+    bridge, model, _vlan = _parse_net0(raw)
     assert bridge == "vmbr1"
     assert model == "vmxnet3"
 
 
 def test_parse_net0_without_mac():
     raw = "net0: vmxnet3,bridge=vmbr2,firewall=0\n"
-    bridge, model = _parse_net0(raw)
+    bridge, model, _vlan = _parse_net0(raw)
     assert bridge == "vmbr2"
     assert model == "vmxnet3"
 
 
 def test_parse_net0_e1000_model():
     raw = "net0: e1000-82545em=AA:BB:CC:DD:EE:FF,bridge=vmbr0,firewall=0\n"
-    bridge, model = _parse_net0(raw)
+    bridge, model, _vlan = _parse_net0(raw)
     assert bridge == "vmbr0"
     assert model == "e1000-82545em"
 
 
 def test_parse_net0_ignores_other_lines():
     raw = "cores: 4\nmemory: 8192\nnet0: vmxnet3,bridge=vmbr3,firewall=0\nsmbios1: uuid=...\n"
-    bridge, model = _parse_net0(raw)
+    bridge, model, _vlan = _parse_net0(raw)
     assert bridge == "vmbr3"
 
 
 def test_parse_net0_no_net0_line():
     raw = "cores: 4\nmemory: 8192\n"
-    bridge, model = _parse_net0(raw)
+    bridge, model, _vlan = _parse_net0(raw)
     assert bridge == "vmbr0"
     assert model == "vmxnet3"
 
@@ -193,3 +193,18 @@ def test_build_clone_plan_clone_step_has_action_risk():
 def test_build_clone_plan_smbios_step_has_safe_risk():
     steps = build_clone_plan(900, 901)
     assert steps[1].risk == "safe"
+
+
+def test_parse_net0_extracts_vlan_tag():
+    raw = "net0: vmxnet3=AA:BB:CC:DD:EE:FF,bridge=vmbr1,tag=20,firewall=0\n"
+    bridge, model, vlan = _parse_net0(raw)
+    assert (bridge, model, vlan) == ("vmbr1", "vmxnet3", "20")
+
+
+def test_clone_preserves_vlan_tag_on_fresh_mac():
+    raw = "net0: vmxnet3=AA:BB:CC:DD:EE:FF,bridge=vmbr1,tag=20,firewall=0\n"
+    steps = build_clone_plan(910, 911, apple_services=True, current_net0=raw)
+    mac_step = next(s for s in steps if "fresh static MAC" in s.title)
+    net0 = mac_step.argv[mac_step.argv.index("--net0") + 1]
+    assert "tag=20" in net0
+    assert "bridge=vmbr1" in net0

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -261,3 +261,22 @@ def test_validate_name_max_length() -> None:
 def test_validate_name_at_max_length_ok() -> None:
     cfg = _valid_cfg(name="a" * 63)
     assert validate_config(cfg) == []
+
+
+def test_validate_config_vlan_valid_and_untagged():
+    from osx_proxmox_next.domain import validate_config
+    base = dict(vmid=901, name="macos-vm", macos="sequoia", cores=8,
+                memory_mb=16384, disk_gb=128, bridge="vmbr0", storage="local-lvm")
+    from osx_proxmox_next.domain import VmConfig
+    assert validate_config(VmConfig(**base)) == []
+    assert validate_config(VmConfig(**base, vlan=20)) == []
+    assert validate_config(VmConfig(**base, vlan=4094)) == []
+
+
+def test_validate_config_vlan_out_of_range():
+    from osx_proxmox_next.domain import VmConfig, validate_config
+    base = dict(vmid=901, name="macos-vm", macos="sequoia", cores=8,
+                memory_mb=16384, disk_gb=128, bridge="vmbr0", storage="local-lvm")
+    for bad in (4095, -3):
+        issues = validate_config(VmConfig(**base, vlan=bad))
+        assert any("VLAN" in i for i in issues), bad

--- a/tests/test_form_handler.py
+++ b/tests/test_form_handler.py
@@ -278,3 +278,23 @@ def test_memory_below_minimum_beats_host_limit_message() -> None:
                                   host_memory_limit_mb=8000)
     assert "memory" in errors
     assert ">= 4096" in errors["memory"]
+# validate_form_values / builder - VLAN tag
+# ---------------------------------------------------------------------------
+
+
+def test_vlan_blank_is_untagged():
+    assert validate_form_values(_valid_values(vlan="")) == {}
+    config = build_vm_config_from_values(_valid_values(vlan=""))
+    assert config is not None and config.vlan == 0
+
+
+def test_vlan_valid_value_accepted():
+    assert validate_form_values(_valid_values(vlan="20")) == {}
+    config = build_vm_config_from_values(_valid_values(vlan="20"))
+    assert config is not None and config.vlan == 20
+
+
+def test_vlan_invalid_values_rejected():
+    for bad in ("0", "4095", "abc", "-1"):
+        errors = validate_form_values(_valid_values(vlan=bad))
+        assert "vlan" in errors, bad

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -946,3 +946,39 @@ def test_recovery_icon_stamp_is_nonfatal():
     assert 'cp "$ICON" $OC_REC/.VolumeIcon.icns &&' not in script
     assert "rm -f $OC_REC/.VolumeIcon.icns" not in script
     assert "rm -f $OC_REC/System/Library/CoreServices/.contentDetails" not in script
+# ---------------------------------------------------------------------------
+# VLAN tag on net0
+# ---------------------------------------------------------------------------
+
+
+def _vlan_config(**kwargs):
+    from osx_proxmox_next.domain import VmConfig
+    base = dict(vmid=907, name="macos-vlan", macos="sequoia", cores=8,
+                memory_mb=16384, disk_gb=128, bridge="vmbr0", storage="local-lvm")
+    base.update(kwargs)
+    return VmConfig(**base)
+
+
+def test_create_net0_includes_vlan_tag(tmp_path, monkeypatch):
+    from osx_proxmox_next.planner import build_plan
+    steps = build_plan(_vlan_config(vlan=20))
+    create = next(s for s in steps if s.title == "Create VM shell")
+    net0 = create.argv[create.argv.index("--net0") + 1]
+    assert net0 == "vmxnet3,bridge=vmbr0,tag=20,firewall=0"
+
+
+def test_create_net0_untagged_by_default(tmp_path):
+    from osx_proxmox_next.planner import build_plan
+    steps = build_plan(_vlan_config())
+    create = next(s for s in steps if s.title == "Create VM shell")
+    net0 = create.argv[create.argv.index("--net0") + 1]
+    assert "tag=" not in net0
+
+
+def test_apple_services_net0_keeps_vlan_tag():
+    from osx_proxmox_next.planner import build_plan
+    steps = build_plan(_vlan_config(vlan=30, apple_services=True))
+    mac_step = next(s for s in steps if "static MAC" in s.title)
+    net0 = mac_step.argv[mac_step.argv.index("--net0") + 1]
+    assert "tag=30" in net0
+    assert "macaddr=" in net0


### PR DESCRIPTION
## Summary
The bash installer could already tag net0 through its advanced settings; the TUI and CLI could not. This closes that gap, so VLAN-segmented networks work from every entry point (#124).

## Changes
- Wizard config step gets an optional "VLAN Tag" field (blank = untagged, validated 1-4094)
- New --vlan flag on the CLI (0/omitted = untagged)
- tag= is applied on both generated net0 values (VM create and the Apple Services static MAC step)
- Cloning an Apple Services VM used to silently drop the source's VLAN tag when regenerating the MAC; now preserved
- README documents the field and flag

## Testing
- [x] Full suite: 961 passed, coverage 97.7%
- [x] Planner tests assert tag placement on both net0 paths and the clone fix

Closes #124
