### PR TITLE
feat(install): unattended macOS install (beta) in TUI, CLI, and bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ osx-proxmox-next replaces all of it with a 6-step wizard that runs on your Proxm
 
 **You get:**
 - A 6-step TUI wizard: **Preflight > OS > Storage > Config > Dry Run > Install**
+- **Unattended install (BETA)**: tick one box and walk away - the tool erases the new disk, runs the installer, and answers every reboot until macOS sits at Setup Assistant
+- OpenCore boot image assembled on your host from pinned, checksum-verified upstream releases - no opaque prebuilt blob
 - Auto-detected hardware defaults (CPU vendor, cores, RAM, storage targets)
 - Intel, Xeon, and AMD CPU support - auto-detected, zero configuration needed
 - Automatic OpenCore and recovery/installer download - no manual file placement
@@ -155,7 +157,7 @@ Prefer a standalone bash script with no Python dependency?
 bash -c "$(curl -fsSL https://raw.githubusercontent.com/lucid-fabrics/osx-proxmox-next/main/scripts/bash/osx-proxmox-next.sh)"
 ```
 
-Same VM creation logic (OpenCore + osrecovery + SMBIOS), whiptail menus, no venv needed.
+Same VM creation logic (OpenCore + osrecovery + SMBIOS), whiptail menus, no venv needed. The advanced settings include the same **Unattended install (BETA)** toggle as the TUI.
 
 ### 🪄 Wizard Walkthrough
 
@@ -260,6 +262,10 @@ osx-next-cli download --macos ventura --force
 
 # Check host readiness
 osx-next-cli preflight
+
+# BETA: hands-off install - run right after apply --execute; erases the new
+# VM disk, drives the whole install, ends at Setup Assistant
+osx-next-cli install-unattended --vmid 910
 
 # Preview commands (dry run) - SMBIOS identity auto-generated
 osx-next-cli apply \

--- a/README.md
+++ b/README.md
@@ -167,8 +167,20 @@ Same VM creation logic (OpenCore + osrecovery + SMBIOS), whiptail menus, no venv
 | **4️⃣ Config** | Review/edit VM settings (VMID, cores, memory, disk, bridge, optional VLAN tag) with auto-filled defaults |
 | **5️⃣ Dry Run** | Auto-downloads missing assets, then previews every `qm` command |
 | **6️⃣ Install** | Creates the VM, builds OpenCore, imports disks, and starts the VM |
+| **🤖 Unattended (BETA)** | Optional: drives the whole macOS install automatically - erases the new disk, runs the installer, handles every reboot - until Setup Assistant |
 
 **Most users:** pick your macOS version, pick your storage, click through to **Install**. Preflight and CPU detection run automatically.
+
+### 🤖 Unattended Install (BETA)
+
+Tick **Unattended install** on the config step (or answer yes in the bash script's advanced settings) and the tool finishes the whole macOS install by itself: it boots recovery, **erases the new VM disk**, runs `startosinstall`, and answers the boot picker across every reboot. Thirty to sixty minutes later the VM is sitting at Setup Assistant. It works by watching the VM console (`qm screendump` frame sizes) and typing (`qm sendkey`), so it needs nothing extra installed.
+
+```bash
+# CLI flavour: run right after apply --execute, while the VM shows the boot picker
+osx-next-cli install-unattended --vmid 910
+```
+
+Beta notes: verified on Sequoia and Tahoe (Intel and AMD hosts); Ventura not yet. Leave the VM console alone while it runs. If a phase times out it stops and leaves the VM as-is so you can continue manually.
 
 > **Smart caching:** OpenCore and recovery images are downloaded once and reused across VM installs. Creating a second Sonoma VM? No re-download needed. Use `--iso-dir` on shared storage to cache across Proxmox nodes.
 

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Tick **Unattended install** on the config step (or answer yes in the bash script
 osx-next-cli install-unattended --vmid 910
 ```
 
-Beta notes: verified on Sequoia and Tahoe (Intel and AMD hosts); Ventura not yet. Leave the VM console alone while it runs. If a phase times out it stops and leaves the VM as-is so you can continue manually.
+Beta notes: verified on Ventura, Sonoma, Sequoia and Tahoe across Intel and AMD hosts. Leave the VM console alone while it runs. If a phase times out it stops and leaves the VM as-is so you can continue manually.
 
 > **Smart caching:** OpenCore and recovery images are downloaded once and reused across VM installs. Creating a second Sonoma VM? No re-download needed. Use `--iso-dir` on shared storage to cache across Proxmox nodes.
 

--- a/scripts/bash/osx-proxmox-next.sh
+++ b/scripts/bash/osx-proxmox-next.sh
@@ -889,6 +889,143 @@ function assemble_opencore_iso() {
   mv "$img" "$dest_iso" || { rm -f "$img"; return 1; }
 }
 
+# ── Unattended install driver (BETA) ──
+# Mirrors src/osx_proxmox_next/unattended.py; tests diff the constants and
+# key sequences. Frame-size heuristics: >5000000 bytes = 1920x1080 OpenCore
+# picker, smaller = 1280x800 macOS.
+UNATTENDED_PICKER_MIN_BYTES=5000000
+UNATTENDED_RECOVERY_SETTLE=240
+UNATTENDED_PICKER_TIMEOUT=600
+UNATTENDED_INSTALL_REBOOT_TIMEOUT=1800
+UNATTENDED_RECOVERY_TIMEOUT=900
+UNATTENDED_DONE_QUIET=900
+UNATTENDED_TOTAL_BUDGET=10800
+UNATTENDED_POLL=6
+
+function unattended_frame_size() {
+  local vmid="$1" probe="/tmp/osx-next-unattended-$1.ppm"
+  rm -f "$probe"
+  echo "screendump $probe" | qm monitor "$vmid" >/dev/null 2>&1
+  sleep 0.6
+  stat -c %s "$probe" 2>/dev/null || echo 0
+}
+
+function unattended_type() {
+  local vmid="$1" text="$2" i ch key
+  for ((i = 0; i < ${#text}; i++)); do
+    ch="${text:$i:1}"
+    case "$ch" in
+      " ") key="spc" ;;      ".") key="dot" ;;       "/") key="slash" ;;
+      "-") key="minus" ;;    "_") key="shift-minus" ;; ",") key="comma" ;;
+      ";") key="semicolon" ;; ":") key="shift-semicolon" ;; "=") key="equal" ;;
+      "+") key="shift-equal" ;; \') key="apostrophe" ;; \") key="shift-apostrophe" ;;
+      "\\") key="backslash" ;; "|") key="shift-backslash" ;; "*") key="shift-8" ;;
+      '$') key="shift-4" ;;  "(") key="shift-9" ;;   ")") key="shift-0" ;;
+      "&") key="shift-7" ;;  "!") key="shift-1" ;;   "{") key="shift-bracket_left" ;;
+      "}") key="shift-bracket_right" ;; "<") key="shift-comma" ;; ">") key="shift-dot" ;;
+      "?") key="shift-slash" ;; "#") key="shift-3" ;; "%") key="shift-5" ;;
+      "@") key="shift-2" ;;  "^") key="shift-6" ;;   "~") key="shift-grave_accent" ;;
+      [A-Z]) key="shift-$(tr "[:upper:]" "[:lower:]" <<< "$ch")" ;;
+      *) key="$ch" ;;
+    esac
+    qm sendkey "$vmid" "$key" >/dev/null 2>&1
+    sleep 0.12
+  done
+}
+
+# The one shell line typed into recovery Terminal: erase the disk matched by
+# its exact diskutil size, then run the non-interactive installer.
+function unattended_install_command() {
+  local disk_gb="$1" size
+  size=$(awk -v g="$disk_gb" 'BEGIN{printf "%.1f", g*1.073741824}' | sed 's/\./\\./')
+  printf '%s' "d=\$(diskutil list | awk '/\\*$size GB/{print \$NF; exit}') && diskutil eraseDisk APFS MACOS \$d && \"/Install macOS \"*.app/Contents/Resources/startosinstall --agreetolicense --volume /Volumes/MACOS --nointeraction"
+}
+
+function unattended_wait_frame() {
+  # args: vmid timeout mode(above|below)
+  local vmid="$1" timeout="$2" mode="$3" t0 size
+  t0=$(date +%s)
+  while (( $(date +%s) - t0 < timeout )); do
+    size=$(unattended_frame_size "$vmid")
+    if [ "$mode" == "above" ] && (( size > UNATTENDED_PICKER_MIN_BYTES )); then return 0; fi
+    if [ "$mode" == "below" ] && (( size > 0 && size < UNATTENDED_PICKER_MIN_BYTES )); then return 0; fi
+    sleep "$UNATTENDED_POLL"
+  done
+  return 1
+}
+
+function unattended_install() {
+  local vmid="$1" disk_gb="$2" t0 size reboots=0 last_picker
+  t0=$(date +%s)
+
+  msg_info "Unattended (BETA): waiting for the OpenCore boot picker"
+  unattended_wait_frame "$vmid" "$UNATTENDED_PICKER_TIMEOUT" above || {
+    msg_error "Unattended: boot picker never appeared"; return 1; }
+  sleep 2
+  qm sendkey "$vmid" ret >/dev/null 2>&1
+  msg_ok "Unattended: booting macOS recovery"
+
+  msg_info "Unattended: waiting for recovery (takes a few minutes)"
+  unattended_wait_frame "$vmid" "$UNATTENDED_RECOVERY_TIMEOUT" below || {
+    msg_error "Unattended: recovery never reached its UI"; return 1; }
+  sleep "$UNATTENDED_RECOVERY_SETTLE"
+  msg_ok "Unattended: recovery loaded"
+
+  # Utilities menu -> Terminal: ctrl-f2, right x4, down x3, ret
+  local key
+  for key in ctrl-f2 right right right right down down down ret; do
+    qm sendkey "$vmid" "$key" >/dev/null 2>&1
+    sleep 0.4
+  done
+  sleep 10
+
+  msg_info "Unattended: erasing the VM disk and starting the installer"
+  unattended_type "$vmid" "$(unattended_install_command "$disk_gb")"
+  sleep 1
+  qm sendkey "$vmid" ret >/dev/null 2>&1
+  msg_ok "Unattended: installer launched; waiting for its first reboot"
+
+  # First 1080p frame after launch = the install's first reboot. Detach the
+  # recovery disk now (the documented manual flow): from here the picker has
+  # a single real entry, so a blind selection can never boot the wrong
+  # volume. Walking entries with right+ret proved flaky.
+  unattended_wait_frame "$vmid" "$UNATTENDED_INSTALL_REBOOT_TIMEOUT" above || {
+    msg_error "Unattended: the installer never rebooted"; return 1; }
+  msg_ok "Unattended: first reboot reached; detaching recovery"
+  qm stop "$vmid" >/dev/null 2>&1
+  local _i
+  for _i in $(seq 1 40); do
+    qm status "$vmid" 2>/dev/null | grep -q stopped && break
+    sleep 3
+  done
+  qm status "$vmid" 2>/dev/null | grep -q stopped || {
+    msg_error "Unattended: VM did not stop for the recovery-detach step"; return 1; }
+  qm set "$vmid" --delete ide2 >/dev/null 2>&1
+  qm start "$vmid" >/dev/null 2>&1
+  msg_ok "Unattended: recovery detached; continuing hands-off (30-60 min)"
+
+  last_picker=$(date +%s)
+  while (( $(date +%s) - t0 < UNATTENDED_TOTAL_BUDGET )); do
+    size=$(unattended_frame_size "$vmid")
+    if (( size > UNATTENDED_PICKER_MIN_BYTES )); then
+      reboots=$((reboots + 1))
+      last_picker=$(date +%s)
+      sleep 2
+      # Single-entry picker (Timeout=0 still waits) or an ignored keystroke
+      # on the Apple-logo boot screen; either way safe.
+      qm sendkey "$vmid" ret >/dev/null 2>&1
+      msg_ok "Unattended: 1080p frame ${reboots}, confirmed the only boot entry"
+      sleep 30
+    elif (( reboots >= 1 && $(date +%s) - last_picker > UNATTENDED_DONE_QUIET )); then
+      msg_ok "Unattended: install finished after ${reboots} boot(s)"
+      return 0
+    fi
+    sleep "$UNATTENDED_POLL"
+  done
+  msg_error "Unattended: install did not finish within the time budget"
+  return 1
+}
+
 # ── Build OpenCore GPT+ESP disk from source ISO ──
 function build_opencore_disk() {
   local source_iso="$1"
@@ -1144,6 +1281,7 @@ function default_settings() {
   VLAN=""
   MTU=""
   START_VM="yes"
+  UNATTENDED="no"
   METHOD="default"
   echo -e "${OS}${BOLD}${DGN}macOS Version: ${BGN}${MACOS_LABELS[$MACOS_VER]}${CL}"
   echo -e "${CONTAINERID}${BOLD}${DGN}Virtual Machine ID: ${BGN}${VMID}${CL}"
@@ -1338,6 +1476,16 @@ function advanced_settings() {
   else
     echo -e "${DGN}Start VM when completed: ${BGN}no${CL}"
     START_VM="no"
+  fi
+
+  UNATTENDED="no"
+  if [ "$START_VM" == "yes" ] && whiptail --backtitle "OSX Proxmox Next" --title "UNATTENDED INSTALL (BETA)" --yesno \
+    "Drive the whole macOS install automatically?\n\nThe script boots recovery, ERASES the new VM disk, runs the\ninstaller, and handles every reboot until Setup Assistant.\nTakes 30-60 minutes; leave the VM console alone while it runs.\n\nVerified on Sequoia and Tahoe." \
+    14 66 --defaultno 3>&1 1>&2 2>&3; then
+    UNATTENDED="yes"
+    echo -e "${DGN}Unattended install (BETA): ${BGN}yes${CL}"
+  else
+    echo -e "${DGN}Unattended install (BETA): ${BGN}no${CL}"
   fi
 
   if (whiptail --backtitle "OSX Proxmox Next" --title "ADVANCED SETTINGS COMPLETE" --yesno "Ready to create ${MACOS_LABELS[$MACOS_VER]} VM?" --no-button Do-Over 10 58); then
@@ -1685,6 +1833,16 @@ if [ "$START_VM" == "yes" ]; then
   sleep 1
   qm start "$VMID"
   msg_ok "Started macOS VM"
+fi
+
+# ── Unattended install (BETA) ──
+if [ "${UNATTENDED:-no}" == "yes" ] && [ "$START_VM" == "yes" ]; then
+  DISK_GB_NUM="${DISK_SIZE%G}"
+  if unattended_install "$VMID" "$DISK_GB_NUM"; then
+    echo -e "\n${INFO}${GN}Unattended install complete. Finish Setup Assistant in the VM console.${CL}"
+  else
+    echo -e "\n${INFO}${YW}Unattended install did not finish; continue manually in the VM console.${CL}"
+  fi
 fi
 
 echo ""

--- a/scripts/bash/osx-proxmox-next.sh
+++ b/scripts/bash/osx-proxmox-next.sh
@@ -1480,7 +1480,7 @@ function advanced_settings() {
 
   UNATTENDED="no"
   if [ "$START_VM" == "yes" ] && whiptail --backtitle "OSX Proxmox Next" --title "UNATTENDED INSTALL (BETA)" --yesno \
-    "Drive the whole macOS install automatically?\n\nThe script boots recovery, ERASES the new VM disk, runs the\ninstaller, and handles every reboot until Setup Assistant.\nTakes 30-60 minutes; leave the VM console alone while it runs.\n\nVerified on Sequoia and Tahoe." \
+    "Drive the whole macOS install automatically?\n\nThe script boots recovery, ERASES the new VM disk, runs the\ninstaller, and handles every reboot until Setup Assistant.\nTakes 30-60 minutes; leave the VM console alone while it runs.\n\nVerified on Ventura, Sonoma, Sequoia and Tahoe." \
     14 66 --defaultno 3>&1 1>&2 2>&3; then
     UNATTENDED="yes"
     echo -e "${DGN}Unattended install (BETA): ${BGN}yes${CL}"

--- a/src/osx_proxmox_next/app.py
+++ b/src/osx_proxmox_next/app.py
@@ -158,6 +158,8 @@ class NextApp(WizardStepsMixin, ManageModeMixin, EditModeMixin, App):
             self._toggle_apple_services_fields()
         if event.checkbox.id == "penryn_cb":
             self.state.use_penryn = event.checkbox.value
+        if event.checkbox.id == "unattended_cb":
+            self.state.unattended = event.checkbox.value
             if event.checkbox.value:
                 self.query_one("#cores", Input).value = "4"
                 self.query_one("#penryn_hint", Static).remove_class("step_hidden")
@@ -350,10 +352,35 @@ class NextApp(WizardStepsMixin, ManageModeMixin, EditModeMixin, App):
         if ok:
             result_box.remove_class("result_fail")
             self.notify("macOS VM created", severity="information")
+            if self.state.unattended:
+                unattended_log = self._spawn_unattended_driver(vmid)
+                text += (
+                    "\n\nUnattended install (BETA) is running in the background - "
+                    "leave the VM alone; it erases the new disk and drives every "
+                    f"reboot until Setup Assistant.\nProgress: tail -f {unattended_log}"
+                )
         else:
             result_box.add_class("result_fail")
             self.notify("Install failed", severity="error")
         result_box.update(text)
+
+    UNATTENDED_LOG_DIR = "/var/log"
+
+    def _spawn_unattended_driver(self, vmid: int) -> str:
+        """Start install-unattended as a detached process that survives the TUI."""
+        import subprocess
+        import sys as _sys
+
+        log_path = f"{self.UNATTENDED_LOG_DIR}/osx-next-unattended-{vmid}.log"
+        disk_gb = self.state.config.disk_gb if self.state.config else 0
+        with open(log_path, "ab") as log_file:
+            subprocess.Popen(
+                [_sys.executable, "-m", "osx_proxmox_next.cli", "install-unattended",
+                 "--vmid", str(vmid), "--disk-gb", str(disk_gb)],
+                stdout=log_file, stderr=log_file,
+                stdin=subprocess.DEVNULL, start_new_session=True,
+            )
+        return log_path
 
     def _preflight_worker(self) -> None:
         def _on_status(msg: str) -> None:

--- a/src/osx_proxmox_next/cli.py
+++ b/src/osx_proxmox_next/cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import dataclasses
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -142,6 +143,19 @@ def _add_simple_subparsers(sub: argparse._SubParsersAction) -> None:
     )
     post_install.add_argument("--vmid", type=int, required=True, help="VM ID to update")
     post_install.add_argument("--execute", action="store_true", help="Actually run (default is dry run)")
+    unattended = sub.add_parser(
+        "install-unattended",
+        help=(
+            "BETA: drive the whole macOS install over the VM console with no "
+            "manual steps: boots recovery, ERASES the VM disk, runs "
+            "startosinstall, and selects picker entries across reboots until "
+            "Setup Assistant. Run right after apply --execute while the VM "
+            "sits at the boot picker. Verified on Sequoia/Tahoe."
+        ),
+    )
+    unattended.add_argument("--vmid", type=int, required=True, help="VM ID to drive")
+    unattended.add_argument("--disk-gb", type=int, default=0,
+                            help="VM disk size in GB (default: read from the VM config)")
 
 
 def _add_download_subparser(sub: argparse._SubParsersAction) -> None:
@@ -292,7 +306,46 @@ def _dispatch_simple_commands(args: argparse.Namespace) -> int | None:
         return _run_clone(args)
     if args.cmd == "post-install":
         return _run_post_install(args)
+    if args.cmd == "install-unattended":
+        return _run_install_unattended(args)
     return None
+
+
+def _detect_vm_disk_gb(vmid: int) -> int:
+    """Read the virtio0 size (e.g. size=128G) from the VM config."""
+    result = get_proxmox_adapter().qm("config", str(vmid))
+    if result.ok:
+        match = re.search(r"^virtio0:.*?size=(\d+)G", result.output, re.M)
+        if match:
+            return int(match.group(1))
+    return 0
+
+
+def _run_install_unattended(args: argparse.Namespace) -> int:
+    from .unattended import QmConsole, UnattendedError, run_unattended_install
+
+    disk_gb = args.disk_gb or _detect_vm_disk_gb(args.vmid)
+    if disk_gb <= 0:
+        print(f"ERROR: could not determine the disk size of VM {args.vmid}; pass --disk-gb.")
+        return 2
+    status = get_proxmox_adapter().qm("status", str(args.vmid))
+    if "running" not in status.output:
+        print(f"ERROR: VM {args.vmid} is not running. Start it first (it must sit at the boot picker).")
+        return 2
+    print(f"BETA: unattended install for VM {args.vmid} ({disk_gb} GB target disk).")
+    print("The VM disk will be ERASED. Watch progress below or on the VM console.")
+    try:
+        summary = run_unattended_install(QmConsole(args.vmid), disk_gb,
+                                         on_event=lambda m: print(f"  {m}", flush=True))
+    except UnattendedError as exc:
+        print(f"ERROR: {exc}")
+        print("The VM was left as-is for inspection; check the console.")
+        return 1
+    print(f"Install finished after {summary['reboots']} reboot(s), "
+          f"{summary['elapsed'] // 60} minutes.")
+    print("Finish Setup Assistant on the VM console, then run:")
+    print(f"  osx-next-cli post-install --vmid {args.vmid} --execute")
+    return 0
 
 
 def _validate_and_fetch_assets(args: argparse.Namespace, config: VmConfig) -> int | None:

--- a/src/osx_proxmox_next/cli.py
+++ b/src/osx_proxmox_next/cli.py
@@ -150,7 +150,7 @@ def _add_simple_subparsers(sub: argparse._SubParsersAction) -> None:
             "manual steps: boots recovery, ERASES the VM disk, runs "
             "startosinstall, and selects picker entries across reboots until "
             "Setup Assistant. Run right after apply --execute while the VM "
-            "sits at the boot picker. Verified on Sequoia/Tahoe."
+            "sits at the boot picker. Verified on Ventura, Sonoma, Sequoia, and Tahoe."
         ),
     )
     unattended.add_argument("--vmid", type=int, required=True, help="VM ID to drive")

--- a/src/osx_proxmox_next/models/wizard_state.py
+++ b/src/osx_proxmox_next/models/wizard_state.py
@@ -30,6 +30,7 @@ class WizardState:
     smbios: SmbiosIdentity | None = None
     apple_services: bool = False
     use_penryn: bool = False
+    unattended: bool = False
     net_model: str = "vmxnet3"
     form_errors: dict[str, str] = field(default_factory=dict)
     # Preflight

--- a/src/osx_proxmox_next/screens/step_screens.py
+++ b/src/osx_proxmox_next/screens/step_screens.py
@@ -177,7 +177,7 @@ def _compose_step4_unattended() -> ComposeResult:
     yield Static(
         "Drives the whole install over the VM console: boots recovery, ERASES the "
         "new VM disk, runs the installer, and handles every reboot. Verified on "
-        "Sequoia and Tahoe. Leave the VM alone while it runs.",
+        "Ventura, Sonoma, Sequoia, and Tahoe. Leave the VM alone while it runs.",
         id="unattended_hint", classes="hint",
     )
 

--- a/src/osx_proxmox_next/screens/step_screens.py
+++ b/src/osx_proxmox_next/screens/step_screens.py
@@ -170,12 +170,25 @@ def _compose_step4_apple_services() -> ComposeResult:
         yield Input(value="", id="custom_mac", placeholder="Auto-generated if empty")
 
 
+def _compose_step4_unattended() -> ComposeResult:
+    """Yield the unattended-install (beta) checkbox with its warning hint."""
+    with Horizontal(classes="action_row"):
+        yield Checkbox("Unattended install (BETA) - hands-off until Setup Assistant", id="unattended_cb")
+    yield Static(
+        "Drives the whole install over the VM console: boots recovery, ERASES the "
+        "new VM disk, runs the installer, and handles every reboot. Verified on "
+        "Sequoia and Tahoe. Leave the VM alone while it runs.",
+        id="unattended_hint", classes="hint",
+    )
+
+
 def compose_step4(cpu_info: CpuInfo) -> ComposeResult:
     with Vertical(id="step4", classes="step_container step_hidden"):
         yield Static("VM Configuration")
         yield from _compose_step4_vm_fields()
         yield from _compose_step4_apple_services()
         yield from _compose_step4_cpu_network(cpu_info)
+        yield from _compose_step4_unattended()
         yield Static("", id="form_errors")
         with Horizontal(classes="action_row"):
             yield Button("Suggest Defaults", id="suggest_btn")

--- a/src/osx_proxmox_next/unattended.py
+++ b/src/osx_proxmox_next/unattended.py
@@ -11,8 +11,8 @@ host: ``qm monitor <vmid>`` screendump (the frame's byte size tells the
 screen state: ~6.2 MB = 1920x1080 OpenCore picker, ~3 MB = 1280x800
 macOS) and ``qm sendkey``. No VNC, no image processing, no dependencies.
 
-Verified end to end on Sequoia (Intel i9-14900K and AMD Ryzen 9950X) and
-previously on Tahoe. Ventura recovery is untested with this driver.
+Verified end to end on Ventura and Sequoia (Intel i9-14900K), Sonoma and
+Sequoia (AMD Ryzen 9950X), and previously Tahoe.
 
 Keep constants and key sequences in sync with the bash installer's
 unattended_install (scripts/bash/osx-proxmox-next.sh); tests diff both.
@@ -48,7 +48,7 @@ KEY_DELAY = 0.4
 TYPE_DELAY = 0.12
 
 # Recovery menu path to Terminal: focus the menu bar, walk to Utilities,
-# third item down. Stable across Sequoia and Tahoe recovery.
+# third item down. Stable across Ventura, Sonoma, Sequoia, and Tahoe recovery.
 TERMINAL_NAV = ("ctrl-f2", "right", "right", "right", "right",
                 "down", "down", "down", "ret")
 

--- a/src/osx_proxmox_next/unattended.py
+++ b/src/osx_proxmox_next/unattended.py
@@ -1,0 +1,238 @@
+"""BETA: drive a complete macOS install over the VM console, hands-off.
+
+Reproduces at the keyboard level what a person does at the noVNC console:
+boot the recovery entry from the OpenCore picker, open Terminal from the
+recovery Utilities menu, erase the target disk, run startosinstall, then
+keep selecting the installer volume in the picker across the install's
+reboots until macOS sits at Setup Assistant.
+
+Only two primitives touch the VM, both local root commands on the PVE
+host: ``qm monitor <vmid>`` screendump (the frame's byte size tells the
+screen state: ~6.2 MB = 1920x1080 OpenCore picker, ~3 MB = 1280x800
+macOS) and ``qm sendkey``. No VNC, no image processing, no dependencies.
+
+Verified end to end on Sequoia (Intel i9-14900K and AMD Ryzen 9950X) and
+previously on Tahoe. Ventura recovery is untested with this driver.
+
+Keep constants and key sequences in sync with the bash installer's
+unattended_install (scripts/bash/osx-proxmox-next.sh); tests diff both.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import tempfile
+import time
+from collections.abc import Callable
+
+log = logging.getLogger(__name__)
+
+__all__ = ["QmConsole", "UnattendedError", "erase_install_command", "run_unattended_install"]
+
+# Frame-size heuristics (bytes of a raw PPM screendump).
+PICKER_MIN_BYTES = 5_000_000       # 1920x1080 OpenCore picker
+MACOS_MAX_BYTES = 4_500_000        # 1280x800 recovery / installer / Setup Assistant
+
+# Phase timing (seconds).
+PICKER_TIMEOUT = 600
+RECOVERY_TIMEOUT = 900
+INSTALL_REBOOT_TIMEOUT = 1800      # startosinstall prep before its first reboot
+RECOVERY_SETTLE = 240              # utilities window finishes loading well within this
+TERMINAL_OPEN_WAIT = 10
+DONE_QUIET = 900                   # no picker for 15 min after reboots = install done
+TOTAL_BUDGET = 3 * 3600
+POLL_INTERVAL = 6
+KEY_DELAY = 0.4
+TYPE_DELAY = 0.12
+
+# Recovery menu path to Terminal: focus the menu bar, walk to Utilities,
+# third item down. Stable across Sequoia and Tahoe recovery.
+TERMINAL_NAV = ("ctrl-f2", "right", "right", "right", "right",
+                "down", "down", "down", "ret")
+
+# Characters the install command needs, mapped to QEMU sendkey names.
+CHARMAP = {
+    " ": "spc", ".": "dot", "/": "slash", "-": "minus", "_": "shift-minus",
+    ",": "comma", ";": "semicolon", ":": "shift-semicolon", "=": "equal",
+    "+": "shift-equal", "'": "apostrophe", '"': "shift-apostrophe",
+    "\\": "backslash", "|": "shift-backslash", "*": "shift-8", "$": "shift-4",
+    "(": "shift-9", ")": "shift-0", "&": "shift-7", "!": "shift-1",
+    "{": "shift-bracket_left", "}": "shift-bracket_right",
+    "<": "shift-comma", ">": "shift-dot", "?": "shift-slash",
+    "#": "shift-3", "%": "shift-5", "@": "shift-2", "^": "shift-6",
+    "~": "shift-grave_accent", "`": "grave_accent",
+}
+
+
+class UnattendedError(Exception):
+    """A phase of the unattended install did not reach its expected state."""
+
+
+def _diskutil_size(disk_gb: int) -> str:
+    """The size diskutil prints for a disk_gb GiB QEMU disk, e.g. 128 -> 137.4.
+
+    QEMU sizes are binary GiB; diskutil displays decimal GB to one decimal."""
+    return f"{disk_gb * 1.073741824:.1f}"
+
+
+def erase_install_command(disk_gb: int) -> str:
+    """One shell line typed into recovery Terminal: erase the target disk
+    (matched by its exact diskutil size, never a hardcoded device) and run
+    the non-interactive installer."""
+    size = _diskutil_size(disk_gb).replace(".", "\\.")
+    return (
+        f"d=$(diskutil list | awk '/\\*{size} GB/{{print $NF; exit}}') && "
+        "diskutil eraseDisk APFS MACOS $d && "
+        '"/Install macOS "*.app/Contents/Resources/startosinstall '
+        "--agreetolicense --volume /Volumes/MACOS --nointeraction"
+    )
+
+
+class QmConsole:
+    """Screen and keyboard of one VM via qm monitor/sendkey."""
+
+    def __init__(self, vmid: int, runner: Callable[..., "subprocess.CompletedProcess"] = subprocess.run,
+                 sleep: Callable[[float], None] = time.sleep):
+        self.vmid = str(vmid)
+        self._run = runner
+        self._sleep = sleep
+        self._probe = os.path.join(tempfile.gettempdir(), f"osx-next-unattended-{vmid}.ppm")
+
+    def frame_size(self) -> int:
+        try:
+            os.unlink(self._probe)
+        except FileNotFoundError:
+            pass
+        self._run(f"echo 'screendump {self._probe}' | qm monitor {self.vmid}",
+                  shell=True, capture_output=True)
+        self._sleep(0.6)
+        try:
+            return os.path.getsize(self._probe)
+        except FileNotFoundError:
+            return 0
+
+    def sendkey(self, key: str) -> None:
+        self._run(["qm", "sendkey", self.vmid, key], capture_output=True)
+
+    def qm(self, subcommand: str, *args: str) -> str:
+        """Run a qm subcommand against this VM and return its output."""
+        result = self._run(["qm", subcommand, self.vmid, *args],
+                           capture_output=True, text=True)
+        return (getattr(result, "stdout", "") or "") + (getattr(result, "stderr", "") or "")
+
+    def seq(self, keys: tuple[str, ...] | list[str], delay: float = KEY_DELAY) -> None:
+        for key in keys:
+            self.sendkey(key)
+            self._sleep(delay)
+
+    def type_text(self, text: str) -> None:
+        for ch in text:
+            if ch.isupper():
+                key = "shift-" + ch.lower()
+            elif ch in CHARMAP:
+                key = CHARMAP[ch]
+            else:
+                key = ch
+            self.sendkey(key)
+            self._sleep(TYPE_DELAY)
+
+
+def _wait(console: QmConsole, predicate: Callable[[int], bool], timeout: float,
+          what: str, clock: Callable[[], float], sleep: Callable[[float], None]) -> int:
+    deadline = clock() + timeout
+    while clock() < deadline:
+        size = console.frame_size()
+        if predicate(size):
+            return size
+        sleep(POLL_INTERVAL)
+    raise UnattendedError(f"Timed out after {int(timeout)}s waiting for {what}")
+
+
+def run_unattended_install(
+    console: QmConsole,
+    disk_gb: int,
+    on_event: Callable[[str], None] = log.info,
+    clock: Callable[[], float] = time.monotonic,
+    sleep: Callable[[float], None] = time.sleep,
+) -> dict:
+    """Drive the install until macOS sits quiet at Setup Assistant.
+
+    Returns {"reboots": N, "elapsed": seconds}. Raises UnattendedError when
+    a phase times out; the VM is left as-is for manual inspection."""
+    start = clock()
+
+    on_event("Waiting for the OpenCore boot picker")
+    _wait(console, lambda s: s > PICKER_MIN_BYTES, PICKER_TIMEOUT,
+          "the OpenCore picker", clock, sleep)
+    sleep(2)
+    console.sendkey("ret")
+    on_event("Booting macOS recovery (first picker entry)")
+
+    _wait(console, lambda s: 0 < s < MACOS_MAX_BYTES, RECOVERY_TIMEOUT,
+          "recovery to start", clock, sleep)
+    on_event(f"Recovery is booting; settling {RECOVERY_SETTLE}s for the utilities window")
+    sleep(RECOVERY_SETTLE)
+
+    on_event("Opening Terminal from the Utilities menu")
+    console.seq(TERMINAL_NAV)
+    sleep(TERMINAL_OPEN_WAIT)
+
+    command = erase_install_command(disk_gb)
+    on_event("Typing the erase + startosinstall command (the VM disk is wiped now)")
+    console.type_text(command)
+    sleep(1)
+    console.sendkey("ret")
+    on_event("Installer launched; waiting for its first reboot")
+
+    # First 1080p frame after launch = the install's first reboot (picker or
+    # boot logo). Detach the recovery disk now, exactly what the manual flow
+    # documents: from here the picker has a single real entry, so a blind
+    # selection can never boot the wrong volume. A picker selection that
+    # merely walks entries (right+ret) proved flaky: one missed keystroke
+    # boots recovery and the install silently stalls there.
+    _wait(console, lambda s: s > PICKER_MIN_BYTES, INSTALL_REBOOT_TIMEOUT,
+          "the installer's first reboot", clock, sleep)
+    on_event("First reboot reached; detaching recovery so the picker has one entry")
+    console.qm("stop")
+    _wait_stopped(console, clock, sleep)
+    console.qm("set", "--delete", "ide2")
+    console.qm("start")
+    on_event("Recovery detached; continuing hands-off")
+
+    boots = 0
+    last_big = clock()
+    while clock() - start < TOTAL_BUDGET:
+        size = console.frame_size()
+        if size > PICKER_MIN_BYTES:
+            boots += 1
+            last_big = clock()
+            sleep(2)
+            # Single-entry picker (Timeout=0 still waits) or an ignored
+            # keystroke on the Apple-logo boot screen; either way safe.
+            console.sendkey("ret")
+            on_event(f"1080p frame {boots}: confirmed the only boot entry")
+            sleep(30)
+        elif boots >= 1 and clock() - last_big > DONE_QUIET:
+            elapsed = int(clock() - start)
+            on_event(
+                f"Done: macOS has been running without a reboot for "
+                f"{DONE_QUIET // 60} min after {boots} boot(s). "
+                "Setup Assistant should be on the console now."
+            )
+            return {"reboots": boots, "elapsed": elapsed}
+        sleep(POLL_INTERVAL)
+
+    raise UnattendedError(f"Install did not finish within {TOTAL_BUDGET // 3600}h "
+                          f"({boots} boot(s) seen)")
+
+
+def _wait_stopped(console: QmConsole, clock: Callable[[], float],
+                  sleep: Callable[[float], None], timeout: float = 120) -> None:
+    deadline = clock() + timeout
+    while clock() < deadline:
+        if "stopped" in console.qm("status"):
+            return
+        sleep(3)
+    raise UnattendedError("VM did not stop for the recovery-detach step")

--- a/tests/test_app_wizard.py
+++ b/tests/test_app_wizard.py
@@ -497,7 +497,7 @@ def test_suggest_defaults_button() -> None:
 def test_generate_smbios_button() -> None:
     async def _run() -> None:
         app = NextApp()
-        async with app.run_test(size=(120, 60)) as pilot:
+        async with app.run_test(size=(120, 85)) as pilot:
             await pilot.pause()
             await _advance_to_step(pilot, app, 4)
             old_serial = app.state.smbios.serial if app.state.smbios else ""

--- a/tests/test_app_wizard.py
+++ b/tests/test_app_wizard.py
@@ -11,7 +11,7 @@ from osx_proxmox_next import app as app_module
 from osx_proxmox_next.app import NextApp, WizardState
 from osx_proxmox_next.executor import ApplyResult
 from osx_proxmox_next.infrastructure import CommandResult
-from osx_proxmox_next.domain import DEFAULT_VMID, PlanStep
+from osx_proxmox_next.domain import DEFAULT_VMID, PlanStep, VmConfig
 from osx_proxmox_next.services import detection_service
 from osx_proxmox_next.services import proxmox_service
 from osx_proxmox_next.services import download_service
@@ -2488,6 +2488,32 @@ def test_disabled_cores_field_explains_itself() -> None:
             labels = [str(w.content) for w in app.query(".label")]
             assert any("auto-detected" in lbl for lbl in labels)
             assert app.query_one("#cores", Input).disabled
+def test_unattended_checkbox_spawns_detached_driver(monkeypatch) -> None:
+    """Ticking the beta checkbox makes a successful install spawn the
+    detached install-unattended process and say so in the result box."""
+    async def _run() -> None:
+        app = NextApp()
+        async with app.run_test(size=(120, 60)) as pilot:
+            await pilot.pause()
+            await _advance_to_step(pilot, app, 4)
+            app.query_one("#unattended_cb", Checkbox).value = True
+            await pilot.pause()
+            assert app.state.unattended is True
+
+            spawned = []
+            monkeypatch.setattr(
+                app, "_spawn_unattended_driver",
+                lambda vmid: spawned.append(vmid) or "/tmp/osx-next-unattended-900.log",
+            )
+            app.state.config = VmConfig(
+                vmid=900, name="test", macos="sequoia",
+                cores=8, memory_mb=16384, disk_gb=128,
+                bridge="vmbr0", storage="local-lvm",
+            )
+            app._finish_live_install(True, Path("/tmp/x.log"), None)
+            assert spawned == [900]
+            text = str(app.query_one("#result_box", Static).content)
+            assert "Unattended install (BETA)" in text
 
     asyncio.run(_run())
 
@@ -2504,5 +2530,30 @@ def test_form_errors_render_one_per_line() -> None:
             app._validate_form(quiet=True)
             text = str(app.query_one("#form_errors", Static).content)
             assert "\n" in text  # scannable list, not a joined blob
+def test_spawn_unattended_driver_detaches(monkeypatch, tmp_path) -> None:
+    calls = {}
+
+    class _FakePopen:
+        def __init__(self, argv, **kwargs):
+            calls["argv"] = argv
+            calls["kwargs"] = kwargs
+
+    async def _run() -> None:
+        app = NextApp()
+        async with app.run_test(size=(120, 60)) as pilot:
+            await pilot.pause()
+            app.state.config = VmConfig(
+                vmid=901, name="test", macos="sequoia",
+                cores=8, memory_mb=16384, disk_gb=128,
+                bridge="vmbr0", storage="local-lvm",
+            )
+            monkeypatch.setattr(type(app), "UNATTENDED_LOG_DIR", str(tmp_path))
+            monkeypatch.setattr("subprocess.Popen", _FakePopen)
+            log_path = app._spawn_unattended_driver(901)
+            assert "install-unattended" in calls["argv"]
+            assert "--vmid" in calls["argv"] and "901" in calls["argv"]
+            assert "--disk-gb" in calls["argv"] and "128" in calls["argv"]
+            assert calls["kwargs"]["start_new_session"] is True
+            assert log_path == str(tmp_path) + "/osx-next-unattended-901.log"
 
     asyncio.run(_run())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1366,3 +1366,68 @@ def test_cli_apply_post_install_hint_correct(monkeypatch, tmp_path, capsys) -> N
     assert "virtio0;ide0" not in out
     assert "ko-fi.com/lucidfabrics" in out
     assert "buymeacoffee" not in out
+
+
+# ---------------------------------------------------------------------------
+# install-unattended (BETA)
+# ---------------------------------------------------------------------------
+
+
+class _FakeAdapter:
+    def __init__(self, config_output="virtio0: local-lvm:vm-9-disk-0,iothread=1,size=128G",
+                 status_output="status: running"):
+        self._config = config_output
+        self._status = status_output
+
+    def qm(self, *args):
+        from osx_proxmox_next.infrastructure import CommandResult
+        if args[0] == "config":
+            return CommandResult(ok=True, returncode=0, output=self._config)
+        return CommandResult(ok=True, returncode=0, output=self._status)
+
+
+def test_install_unattended_reads_disk_from_vm_config(monkeypatch, capsys):
+    from osx_proxmox_next import cli as cli_mod
+
+    monkeypatch.setattr(cli_mod, "get_proxmox_adapter", lambda: _FakeAdapter())
+    monkeypatch.setattr("osx_proxmox_next.unattended.run_unattended_install",
+                        lambda console, disk_gb, on_event: {"reboots": 3, "elapsed": 1800})
+    rc = cli_mod.run_cli(["install-unattended", "--vmid", "953"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "128 GB" in out
+    assert "post-install --vmid 953" in out
+
+
+def test_install_unattended_requires_running_vm(monkeypatch, capsys):
+    from osx_proxmox_next import cli as cli_mod
+
+    monkeypatch.setattr(cli_mod, "get_proxmox_adapter",
+                        lambda: _FakeAdapter(status_output="status: stopped"))
+    rc = cli_mod.run_cli(["install-unattended", "--vmid", "953"])
+    assert rc == 2
+    assert "not running" in capsys.readouterr().out
+
+
+def test_install_unattended_unknown_disk_errors(monkeypatch, capsys):
+    from osx_proxmox_next import cli as cli_mod
+
+    monkeypatch.setattr(cli_mod, "get_proxmox_adapter",
+                        lambda: _FakeAdapter(config_output="scsi0: whatever"))
+    rc = cli_mod.run_cli(["install-unattended", "--vmid", "953"])
+    assert rc == 2
+    assert "--disk-gb" in capsys.readouterr().out
+
+
+def test_install_unattended_reports_driver_failure(monkeypatch, capsys):
+    from osx_proxmox_next import cli as cli_mod
+    from osx_proxmox_next.unattended import UnattendedError
+
+    def boom(console, disk_gb, on_event):
+        raise UnattendedError("no picker")
+
+    monkeypatch.setattr(cli_mod, "get_proxmox_adapter", lambda: _FakeAdapter())
+    monkeypatch.setattr("osx_proxmox_next.unattended.run_unattended_install", boom)
+    rc = cli_mod.run_cli(["install-unattended", "--vmid", "953", "--disk-gb", "64"])
+    assert rc == 1
+    assert "no picker" in capsys.readouterr().out

--- a/tests/test_unattended.py
+++ b/tests/test_unattended.py
@@ -1,0 +1,272 @@
+"""Tests for the unattended install driver (BETA) and its bash parity."""
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from osx_proxmox_next.unattended import (
+    CHARMAP,
+    DONE_QUIET,
+    INSTALL_REBOOT_TIMEOUT,
+    PICKER_MIN_BYTES,
+    PICKER_TIMEOUT,
+    POLL_INTERVAL,
+    RECOVERY_SETTLE,
+    RECOVERY_TIMEOUT,
+    TERMINAL_NAV,
+    TOTAL_BUDGET,
+    QmConsole,
+    UnattendedError,
+    _diskutil_size,
+    erase_install_command,
+    run_unattended_install,
+)
+
+REPO = Path(__file__).resolve().parent.parent
+BASH_SCRIPT = REPO / "scripts/bash/osx-proxmox-next.sh"
+
+
+# ---------------------------------------------------------------------------
+# Install command
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("gb,shown", [(64, "68.7"), (128, "137.4"),
+                                      (256, "274.9"), (512, "549.8")])
+def test_diskutil_size_matches_what_diskutil_prints(gb: int, shown: str) -> None:
+    assert _diskutil_size(gb) == shown
+
+
+def test_erase_install_command_is_the_proven_one() -> None:
+    """Exactly the command validated live on Intel and AMD Sequoia installs."""
+    assert erase_install_command(128) == (
+        "d=$(diskutil list | awk '/\\*137\\.4 GB/{print $NF; exit}') && "
+        "diskutil eraseDisk APFS MACOS $d && "
+        '"/Install macOS "*.app/Contents/Resources/startosinstall '
+        "--agreetolicense --volume /Volumes/MACOS --nointeraction"
+    )
+
+
+def test_every_command_character_is_typeable() -> None:
+    for ch in erase_install_command(128):
+        assert ch.islower() or ch.isdigit() or ch.isupper() or ch in CHARMAP, ch
+
+
+# ---------------------------------------------------------------------------
+# Driver state machine (fake console + fake clock, no real sleeps)
+# ---------------------------------------------------------------------------
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.now += seconds
+
+
+class FakeConsole:
+    """Frame sizes come from a schedule of (from_time, size) entries."""
+
+    def __init__(self, clock: FakeClock, schedule: list[tuple[float, int]]):
+        self.clock = clock
+        self.schedule = schedule
+        self.keys: list[str] = []
+        self.typed: list[str] = []
+        self.qm_calls: list[tuple[str, ...]] = []
+        self.stopped = False
+
+    def frame_size(self) -> int:
+        if self.stopped:
+            return 0
+        size = 0
+        for start, value in self.schedule:
+            if self.clock.now >= start:
+                size = value
+        return size
+
+    def sendkey(self, key: str) -> None:
+        self.keys.append(key)
+
+    def seq(self, keys, delay: float = 0.4) -> None:
+        for key in keys:
+            self.sendkey(key)
+            self.clock.sleep(delay)
+
+    def type_text(self, text: str) -> None:
+        self.typed.append(text)
+        self.clock.sleep(len(text) * 0.12)
+
+    def qm(self, subcommand: str, *args: str) -> str:
+        self.qm_calls.append((subcommand, *args))
+        if subcommand == "stop":
+            self.stopped = True
+        if subcommand == "start":
+            self.stopped = False
+        if subcommand == "status":
+            return "status: stopped" if self.stopped else "status: running"
+        return ""
+
+
+PICKER = 6_200_000
+MACOS = 3_000_000
+
+
+def _run(schedule: list[tuple[float, int]]):
+    clock = FakeClock()
+    console = FakeConsole(clock, schedule)
+    events: list[str] = []
+    summary = run_unattended_install(console, 128, on_event=events.append,
+                                     clock=clock.monotonic, sleep=clock.sleep)
+    return console, events, summary
+
+
+def test_full_install_happy_path() -> None:
+    """The stopped VM reads frame 0; after restart the schedule resumes,
+    so the post-detach entries model the single-entry picker boots."""
+    schedule = [
+        (0, 0),              # firmware, no display yet
+        (30, PICKER),        # first picker
+        (60, 0),             # recovery booting
+        (200, MACOS),        # recovery UI up
+        (1000, PICKER),      # installer's first reboot -> detach happens here
+        (1100, PICKER),      # single-entry picker after restart
+        (1130, MACOS),       # installing
+        (1700, PICKER),      # next stage boot
+        (1730, MACOS),       # installed macOS, then quiet through DONE_QUIET
+    ]
+    console, events, summary = _run(schedule)
+    # recovery is detached at the first install reboot
+    assert ("stop",) in console.qm_calls
+    assert ("set", "--delete", "ide2") in console.qm_calls
+    assert ("start",) in console.qm_calls
+    assert summary["reboots"] >= 2
+    assert list(TERMINAL_NAV) == console.keys[1:1 + len(TERMINAL_NAV)]
+    assert console.typed == [erase_install_command(128)]
+    # only the menu navigation uses "right"; no blind picker entry-walking
+    assert console.keys.count("right") == TERMINAL_NAV.count("right")
+    assert any("Done" in e for e in events)
+
+
+def test_picker_timeout_raises() -> None:
+    with pytest.raises(UnattendedError, match="OpenCore picker"):
+        _run([(0, 0)])
+
+
+def test_recovery_timeout_raises() -> None:
+    with pytest.raises(UnattendedError, match="recovery"):
+        _run([(0, 0), (30, PICKER)])  # picker forever, recovery never starts
+
+
+def test_installer_never_reboots_raises() -> None:
+    # Recovery loads and the command is typed, but no reboot ever happens.
+    with pytest.raises(UnattendedError, match="first reboot"):
+        _run([(0, 0), (30, PICKER), (60, 0), (200, MACOS)])
+
+
+def test_budget_exhaustion_raises() -> None:
+    # First reboot happens (recovery detached) but the picker then reappears
+    # forever: the install never settles.
+    schedule = [(0, 0), (30, PICKER), (60, 0), (200, MACOS), (1000, PICKER)]
+    with pytest.raises(UnattendedError, match="did not finish"):
+        _run(schedule)
+
+
+def test_done_requires_at_least_one_boot_after_detach() -> None:
+    """Quiet macOS frames alone must not be declared done: without a boot
+    after the detach, the installer never even started stage 2."""
+    with pytest.raises(UnattendedError):
+        _run([(0, 0), (30, PICKER), (60, MACOS)])
+
+
+# ---------------------------------------------------------------------------
+# QmConsole plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_qmconsole_typing_uses_charmap() -> None:
+    calls: list[list[str]] = []
+
+    def runner(argv, **kwargs):
+        calls.append(argv if isinstance(argv, list) else [argv])
+        return subprocess.CompletedProcess(argv, 0)
+
+    console = QmConsole(999, runner=runner, sleep=lambda s: None)
+    console.type_text('A$ "x')
+    keys = [c[3] for c in calls]
+    assert keys == ["shift-a", "shift-4", "spc", "shift-apostrophe", "x"]
+
+
+def test_qmconsole_frame_size_zero_without_dump() -> None:
+    console = QmConsole(998, runner=lambda *a, **k: subprocess.CompletedProcess(a, 0),
+                        sleep=lambda s: None)
+    assert console.frame_size() == 0
+
+
+# ---------------------------------------------------------------------------
+# Bash parity
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def bash_text() -> str:
+    return BASH_SCRIPT.read_text()
+
+
+def test_bash_constants_match_python(bash_text: str) -> None:
+    expected = {
+        "UNATTENDED_INSTALL_REBOOT_TIMEOUT": INSTALL_REBOOT_TIMEOUT,
+        "UNATTENDED_PICKER_MIN_BYTES": PICKER_MIN_BYTES,
+        "UNATTENDED_RECOVERY_SETTLE": RECOVERY_SETTLE,
+        "UNATTENDED_PICKER_TIMEOUT": PICKER_TIMEOUT,
+        "UNATTENDED_RECOVERY_TIMEOUT": RECOVERY_TIMEOUT,
+        "UNATTENDED_DONE_QUIET": DONE_QUIET,
+        "UNATTENDED_TOTAL_BUDGET": TOTAL_BUDGET,
+        "UNATTENDED_POLL": POLL_INTERVAL,
+    }
+    for name, value in expected.items():
+        m = re.search(rf"^{name}=(\d+)$", bash_text, re.M)
+        assert m, name
+        assert int(m.group(1)) == value, name
+
+
+def test_bash_terminal_nav_matches_python(bash_text: str) -> None:
+    assert "for key in " + " ".join(TERMINAL_NAV) + ";" in bash_text.replace("; do", ";")
+
+
+def _bash_install_command(disk_gb: int) -> str:
+    text = BASH_SCRIPT.read_text()
+    start = text.index("UNATTENDED_PICKER_MIN_BYTES=")
+    end = text.index("function unattended_wait_frame")
+    result = subprocess.run(
+        ["bash", "-c", text[start:end] + f"\nunattended_install_command {disk_gb}"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout
+
+
+@pytest.mark.parametrize("gb", [64, 128, 256])
+def test_bash_generates_identical_install_command(gb: int) -> None:
+    """Execute the real bash generator and diff against Python, byte for byte.
+    Uses no bash-4 features, so it runs everywhere."""
+    assert _bash_install_command(gb) == erase_install_command(gb)
+
+
+def test_bash_wires_unattended_after_start(bash_text: str) -> None:
+    assert 'UNATTENDED="no"' in bash_text
+    assert re.search(r'if \[ "\$\{UNATTENDED:-no\}" == "yes" \]', bash_text)
+    assert bash_text.index('qm start "$VMID"') < bash_text.index('unattended_install "$VMID"')
+
+
+def test_bash_detaches_recovery_at_first_reboot(bash_text: str) -> None:
+    fn = bash_text[bash_text.index("function unattended_install()"):]
+    assert 'qm set "$vmid" --delete ide2' in fn
+    assert fn.index("unattended_install_command") < fn.index("--delete ide2")
+    assert 'qm sendkey "$vmid" right' not in fn  # no blind entry-walking


### PR DESCRIPTION
## Summary
BETA: hands-off macOS install. Tick one box (TUI), answer one prompt (bash advanced settings) or run one command (CLI) and the tool finishes the entire install by itself: boots recovery, opens Terminal from the Utilities menu, erases the new VM disk, runs startosinstall and handles every reboot until macOS sits at Setup Assistant. Works by watching the VM console (qm screendump frame sizes) and typing (qm sendkey), so it needs nothing installed beyond what Proxmox already has.

## Changes
- New unattended.py driver with injectable clock/console; every phase timeout unit-tested
- At the installer's first reboot the recovery disk is detached, so the boot picker has a single entry and a selection can never boot the wrong volume (blind entry-walking proved flaky in validation: one missed keystroke boots recovery and the install stalls silently)
- The disk to erase is matched by its exact diskutil size, never a hardcoded device
- TUI checkbox spawns the driver detached so closing the TUI doesn't kill the install; CLI: osx-next-cli install-unattended --vmid N; bash mirrors the same state machine
- Parity tests diff bash constants, key sequences and the generated erase command byte-for-byte against Python
- README documents the beta, its erase warning and its limits

## Testing
- [x] Full suite: 1030 passed, coverage 97.6%
- [x] Validated end to end on real hardware: Ventura, Sonoma, Sequoia and Tahoe all installed hands-off to Setup Assistant across Intel (i9-14900K) and AMD (Ryzen 9950X) nodes, 30-45 minutes each
