### PR TITLE
fix(unattended): wait for a stable recovery screen, detect wedged guests, power-cycle

### DIFF
--- a/scripts/bash/osx-proxmox-next.sh
+++ b/scripts/bash/osx-proxmox-next.sh
@@ -895,6 +895,8 @@ function assemble_opencore_iso() {
 # picker, smaller = 1280x800 macOS.
 UNATTENDED_PICKER_MIN_BYTES=5000000
 UNATTENDED_RECOVERY_SETTLE=240
+UNATTENDED_RECOVERY_STILL_MAX=600
+UNATTENDED_RECOVERY_STILL_FRAMES=3
 UNATTENDED_PICKER_TIMEOUT=600
 UNATTENDED_INSTALL_REBOOT_TIMEOUT=1800
 UNATTENDED_RECOVERY_TIMEOUT=900
@@ -908,6 +910,34 @@ function unattended_frame_size() {
   echo "screendump $probe" | qm monitor "$vmid" >/dev/null 2>&1
   sleep 0.6
   stat -c %s "$probe" 2>/dev/null || echo 0
+}
+
+function unattended_frame_hash() {
+  local vmid="$1" probe="/tmp/osx-next-unattended-$1.ppm"
+  [ "$(unattended_frame_size "$vmid")" == "0" ] && return 0
+  md5sum "$probe" 2>/dev/null | cut -d' ' -f1
+}
+
+# Hold until the recovery screen stops animating. A cold first boot can still
+# be in Recovery Assistant ("Examining volumes", a spinner) when the settle
+# expires; its menu bar carries no Utilities menu, so the Terminal navigation
+# walks the wrong menu bar, the command lands in the utilities window that
+# appears later and its closing return runs "Restore from Time Machine".
+function unattended_wait_still() {
+  local vmid="$1" t0 seen cur still=1
+  t0=$(date +%s)
+  seen=$(unattended_frame_hash "$vmid")
+  while (( $(date +%s) - t0 < UNATTENDED_RECOVERY_STILL_MAX )); do
+    sleep "$UNATTENDED_POLL"
+    cur=$(unattended_frame_hash "$vmid")
+    if [ -n "$cur" ] && [ "$cur" == "$seen" ]; then
+      still=$((still + 1))
+      (( still >= UNATTENDED_RECOVERY_STILL_FRAMES )) && return 0
+    else
+      seen="$cur"; still=1
+    fi
+  done
+  msg_info "Unattended: recovery screen never stopped moving; navigating anyway"
 }
 
 function unattended_type() {
@@ -969,6 +999,7 @@ function unattended_install() {
   unattended_wait_frame "$vmid" "$UNATTENDED_RECOVERY_TIMEOUT" below || {
     msg_error "Unattended: recovery never reached its UI"; return 1; }
   sleep "$UNATTENDED_RECOVERY_SETTLE"
+  unattended_wait_still "$vmid"
   msg_ok "Unattended: recovery loaded"
 
   # Utilities menu -> Terminal: ctrl-f2, right x4, down x3, ret

--- a/scripts/bash/osx-proxmox-next.sh
+++ b/scripts/bash/osx-proxmox-next.sh
@@ -902,6 +902,8 @@ UNATTENDED_INSTALL_REBOOT_TIMEOUT=1800
 UNATTENDED_RECOVERY_TIMEOUT=900
 UNATTENDED_DONE_QUIET=900
 UNATTENDED_HUNG_STILL=600
+UNATTENDED_PICKER_REPRESS=30
+UNATTENDED_MAX_POWER_CYCLES=2
 UNATTENDED_TOTAL_BUDGET=10800
 UNATTENDED_POLL=6
 
@@ -977,6 +979,15 @@ function unattended_install_command() {
   printf '%s' "d=\$(diskutil list | awk '/\\*$size GB/{print \$NF; exit}') && diskutil eraseDisk APFS MACOS \$d && \"/Install macOS \"*.app/Contents/Resources/startosinstall --agreetolicense --volume /Volumes/MACOS --nointeraction"
 }
 
+function unattended_wait_stopped() {
+  local vmid="$1" _i
+  for _i in $(seq 1 40); do
+    qm status "$vmid" 2>/dev/null | grep -q stopped && return 0
+    sleep 3
+  done
+  return 1
+}
+
 function unattended_wait_frame() {
   # args: vmid timeout mode(above|below)
   local vmid="$1" timeout="$2" mode="$3" t0 size
@@ -1030,19 +1041,16 @@ function unattended_install() {
     msg_error "Unattended: the installer never rebooted"; return 1; }
   msg_ok "Unattended: first reboot reached; detaching recovery"
   qm stop "$vmid" >/dev/null 2>&1
-  local _i
-  for _i in $(seq 1 40); do
-    qm status "$vmid" 2>/dev/null | grep -q stopped && break
-    sleep 3
-  done
-  qm status "$vmid" 2>/dev/null | grep -q stopped || {
+  unattended_wait_stopped "$vmid" || {
     msg_error "Unattended: VM did not stop for the recovery-detach step"; return 1; }
   qm set "$vmid" --delete ide2 >/dev/null 2>&1
   qm start "$vmid" >/dev/null 2>&1
   msg_ok "Unattended: recovery detached; continuing hands-off (30-60 min)"
 
+  local last_press cycles=0 changed
   last_picker=$(date +%s)
-  last_change=$(date +%s)
+  last_change=$last_picker
+  last_press=$((last_picker - UNATTENDED_PICKER_REPRESS))
   seen=""
   while (( $(date +%s) - t0 < UNATTENDED_TOTAL_BUDGET )); do
     size=$(unattended_frame_size "$vmid")
@@ -1051,23 +1059,56 @@ function unattended_install() {
     # Running macOS always moves, if only because the Setup Assistant menu bar
     # ticks its clock every minute; a wedged kernel never redraws.
     digest=$(unattended_probe_hash "$vmid")
+    changed=0
     if [ -n "$digest" ] && [ "$digest" != "$seen" ]; then
       seen="$digest"
       last_change=$(date +%s)
+      changed=1
     fi
     if (( size > UNATTENDED_PICKER_MIN_BYTES )); then
-      reboots=$((reboots + 1))
       last_picker=$(date +%s)
-      sleep 2
-      # Single-entry picker (Timeout=0 still waits) or an ignored keystroke
-      # on the Apple-logo boot screen; either way safe.
-      qm sendkey "$vmid" ret >/dev/null 2>&1
-      msg_ok "Unattended: 1080p frame ${reboots}, confirmed the only boot entry"
-      sleep 30
+      if (( changed )); then
+        reboots=$((reboots + 1))
+        sleep 2
+        # Single-entry picker (Timeout=0 still waits) or an ignored keystroke
+        # on the Apple-logo boot screen; either way safe.
+        qm sendkey "$vmid" ret >/dev/null 2>&1
+        last_press=$(date +%s)
+        msg_ok "Unattended: 1080p frame ${reboots}, confirmed the only boot entry"
+        sleep "$UNATTENDED_PICKER_REPRESS"
+      elif (( $(date +%s) - last_press >= UNATTENDED_PICKER_REPRESS )); then
+        # A byte-identical 1080p frame is a picker still parked on its entry:
+        # Timeout=0 waits forever and the first return was dropped. Press
+        # again, quietly, so the log keeps one line per boot, not per poll.
+        qm sendkey "$vmid" ret >/dev/null 2>&1
+        last_press=$(date +%s)
+      fi
     elif (( reboots >= 1 && $(date +%s) - last_change > UNATTENDED_HUNG_STILL )); then
-      msg_error "Unattended: macOS appears hung: screen unchanged for $((UNATTENDED_HUNG_STILL / 60)) min"
-      return 1
-    elif (( reboots >= 1 && $(date +%s) - last_picker > UNATTENDED_DONE_QUIET )); then
+      # The guest's own reboot can wedge in an MP rendezvous with every vCPU
+      # spinning and the framebuffer stuck on its last frame. qm reset does
+      # not clear that; only a full stop/start does, and it boots the
+      # finished install to Setup Assistant in about 100s.
+      if (( cycles >= UNATTENDED_MAX_POWER_CYCLES )); then
+        msg_error "Unattended: macOS appears hung: screen unchanged for $((UNATTENDED_HUNG_STILL / 60)) min"
+        return 1
+      fi
+      cycles=$((cycles + 1))
+      msg_info "Unattended: guest appears wedged (screen unchanged for $((UNATTENDED_HUNG_STILL / 60)) min); power-cycling"
+      qm stop "$vmid" >/dev/null 2>&1
+      unattended_wait_stopped "$vmid" || {
+        msg_error "Unattended: VM did not stop for the power cycle"; return 1; }
+      qm start "$vmid" >/dev/null 2>&1
+      # The restarted guest earns its quiet window again: coming back from a
+      # power cycle is not by itself proof the install finished.
+      last_change=$(date +%s)
+      last_picker=$last_change
+      seen=""
+    # Ordering: HUNG_STILL (10 min) is checked above and is shorter than
+    # DONE_QUIET (15 min), so a frozen screen always power-cycles or fails
+    # before it can get here. The last_change clause is the belt to that
+    # guard's braces: a still screen is never a finished install.
+    elif (( reboots >= 1 && $(date +%s) - last_picker > UNATTENDED_DONE_QUIET
+            && $(date +%s) - last_change <= UNATTENDED_DONE_QUIET )); then
       msg_ok "Unattended: install finished after ${reboots} boot(s)"
       return 0
     fi

--- a/scripts/bash/osx-proxmox-next.sh
+++ b/scripts/bash/osx-proxmox-next.sh
@@ -901,6 +901,7 @@ UNATTENDED_PICKER_TIMEOUT=600
 UNATTENDED_INSTALL_REBOOT_TIMEOUT=1800
 UNATTENDED_RECOVERY_TIMEOUT=900
 UNATTENDED_DONE_QUIET=900
+UNATTENDED_HUNG_STILL=600
 UNATTENDED_TOTAL_BUDGET=10800
 UNATTENDED_POLL=6
 
@@ -912,10 +913,15 @@ function unattended_frame_size() {
   stat -c %s "$probe" 2>/dev/null || echo 0
 }
 
+# md5 of the frame unattended_frame_size last wrote, without dumping again.
+function unattended_probe_hash() {
+  md5sum "/tmp/osx-next-unattended-$1.ppm" 2>/dev/null | cut -d' ' -f1
+}
+
 function unattended_frame_hash() {
-  local vmid="$1" probe="/tmp/osx-next-unattended-$1.ppm"
+  local vmid="$1"
   [ "$(unattended_frame_size "$vmid")" == "0" ] && return 0
-  md5sum "$probe" 2>/dev/null | cut -d' ' -f1
+  unattended_probe_hash "$vmid"
 }
 
 # Hold until the recovery screen stops animating. A cold first boot can still
@@ -985,7 +991,7 @@ function unattended_wait_frame() {
 }
 
 function unattended_install() {
-  local vmid="$1" disk_gb="$2" t0 size reboots=0 last_picker
+  local vmid="$1" disk_gb="$2" t0 size reboots=0 last_picker last_change digest seen
   t0=$(date +%s)
 
   msg_info "Unattended (BETA): waiting for the OpenCore boot picker"
@@ -1036,8 +1042,19 @@ function unattended_install() {
   msg_ok "Unattended: recovery detached; continuing hands-off (30-60 min)"
 
   last_picker=$(date +%s)
+  last_change=$(date +%s)
+  seen=""
   while (( $(date +%s) - t0 < UNATTENDED_TOTAL_BUDGET )); do
     size=$(unattended_frame_size "$vmid")
+    # macOS wedged behind the boot logo is exactly as quiet as a finished
+    # install: no picker, no 1080p frame. What separates them is motion.
+    # Running macOS always moves, if only because the Setup Assistant menu bar
+    # ticks its clock every minute; a wedged kernel never redraws.
+    digest=$(unattended_probe_hash "$vmid")
+    if [ -n "$digest" ] && [ "$digest" != "$seen" ]; then
+      seen="$digest"
+      last_change=$(date +%s)
+    fi
     if (( size > UNATTENDED_PICKER_MIN_BYTES )); then
       reboots=$((reboots + 1))
       last_picker=$(date +%s)
@@ -1047,6 +1064,9 @@ function unattended_install() {
       qm sendkey "$vmid" ret >/dev/null 2>&1
       msg_ok "Unattended: 1080p frame ${reboots}, confirmed the only boot entry"
       sleep 30
+    elif (( reboots >= 1 && $(date +%s) - last_change > UNATTENDED_HUNG_STILL )); then
+      msg_error "Unattended: macOS appears hung: screen unchanged for $((UNATTENDED_HUNG_STILL / 60)) min"
+      return 1
     elif (( reboots >= 1 && $(date +%s) - last_picker > UNATTENDED_DONE_QUIET )); then
       msg_ok "Unattended: install finished after ${reboots} boot(s)"
       return 0

--- a/src/osx_proxmox_next/unattended.py
+++ b/src/osx_proxmox_next/unattended.py
@@ -46,6 +46,8 @@ RECOVERY_STILL_FRAMES = 3          # identical consecutive frames = nothing anim
 TERMINAL_OPEN_WAIT = 10
 DONE_QUIET = 900                   # no picker for 15 min after reboots = install done
 HUNG_STILL = 600                   # frame byte-identical for 10 min = macOS is wedged
+PICKER_REPRESS = 30                # seconds between return presses at a parked picker
+MAX_POWER_CYCLES = 2               # stop/start attempts on a wedged guest before giving up
 TOTAL_BUDGET = 3 * 3600
 POLL_INTERVAL = 6
 KEY_DELAY = 0.4
@@ -249,6 +251,8 @@ def run_unattended_install(
     boots = 0
     last_big = clock()
     last_change = clock()
+    last_press = clock() - PICKER_REPRESS
+    cycles = 0
     seen = ""
     while clock() - start < TOTAL_BUDGET:
         size = console.frame_size()
@@ -257,23 +261,53 @@ def run_unattended_install(
         # Running macOS always moves, if only because the Setup Assistant menu
         # bar ticks its clock every minute; a wedged kernel never redraws.
         digest = console.probe_hash()
-        if digest and digest != seen:
+        changed = bool(digest) and digest != seen
+        if changed:
             seen = digest
             last_change = clock()
         if size > PICKER_MIN_BYTES:
-            boots += 1
             last_big = clock()
-            sleep(2)
-            # Single-entry picker (Timeout=0 still waits) or an ignored
-            # keystroke on the Apple-logo boot screen; either way safe.
-            console.sendkey("ret")
-            on_event(f"1080p frame {boots}: confirmed the only boot entry")
-            sleep(30)
+            if changed:
+                boots += 1
+                sleep(2)
+                # Single-entry picker (Timeout=0 still waits) or an ignored
+                # keystroke on the Apple-logo boot screen; either way safe.
+                console.sendkey("ret")
+                last_press = clock()
+                on_event(f"1080p frame {boots}: confirmed the only boot entry")
+                sleep(PICKER_REPRESS)
+            elif clock() - last_press >= PICKER_REPRESS:
+                # A byte-identical 1080p frame is a picker still parked on its
+                # entry: Timeout=0 waits forever and the first return was
+                # dropped. Press again, quietly, so the log keeps one line
+                # per boot instead of one per poll.
+                console.sendkey("ret")
+                last_press = clock()
         elif boots >= 1 and clock() - last_change > HUNG_STILL:
-            raise UnattendedError(
-                f"macOS appears hung: screen unchanged for {HUNG_STILL // 60} min"
-            )
-        elif boots >= 1 and clock() - last_big > DONE_QUIET:
+            # The guest's own reboot can wedge in an MP rendezvous with every
+            # vCPU spinning and the framebuffer stuck on its last frame. qm
+            # reset does not clear that; only a full stop/start does, and it
+            # boots the finished install to Setup Assistant in about 100s.
+            if cycles >= MAX_POWER_CYCLES:
+                raise UnattendedError(
+                    f"macOS appears hung: screen unchanged for {HUNG_STILL // 60} min"
+                )
+            cycles += 1
+            on_event(f"Guest appears wedged (screen unchanged for "
+                     f"{HUNG_STILL // 60} min); power-cycling")
+            console.qm("stop")
+            _wait_stopped(console, clock, sleep)
+            console.qm("start")
+            # The restarted guest earns its quiet window again: coming back
+            # from a power cycle is not by itself proof the install finished.
+            last_change = last_big = clock()
+            seen = ""
+        # Ordering: HUNG_STILL (10 min) is checked above and is shorter than
+        # DONE_QUIET (15 min), so a frozen screen always power-cycles or
+        # raises before it can get here. The last_change clause is the belt
+        # to that guard's braces: a still screen is never a finished install.
+        elif (boots >= 1 and clock() - last_big > DONE_QUIET
+              and clock() - last_change <= DONE_QUIET):
             elapsed = int(clock() - start)
             on_event(
                 f"Done: macOS has been running without a reboot for "
@@ -294,4 +328,4 @@ def _wait_stopped(console: QmConsole, clock: Callable[[], float],
         if "stopped" in console.qm("status"):
             return
         sleep(3)
-    raise UnattendedError("VM did not stop for the recovery-detach step")
+    raise UnattendedError("VM did not stop when asked to (detach or power cycle)")

--- a/src/osx_proxmox_next/unattended.py
+++ b/src/osx_proxmox_next/unattended.py
@@ -45,6 +45,7 @@ RECOVERY_STILL_MAX = 600           # extra grace while the recovery screen is st
 RECOVERY_STILL_FRAMES = 3          # identical consecutive frames = nothing animating
 TERMINAL_OPEN_WAIT = 10
 DONE_QUIET = 900                   # no picker for 15 min after reboots = install done
+HUNG_STILL = 600                   # frame byte-identical for 10 min = macOS is wedged
 TOTAL_BUDGET = 3 * 3600
 POLL_INTERVAL = 6
 KEY_DELAY = 0.4
@@ -116,12 +117,19 @@ class QmConsole:
         except FileNotFoundError:
             return 0
 
+    def probe_hash(self) -> str:
+        """md5 of the screendump frame_size() last wrote; "" when there is none."""
+        try:
+            with open(self._probe, "rb") as probe:
+                return hashlib.md5(probe.read()).hexdigest()
+        except FileNotFoundError:
+            return ""
+
     def frame_hash(self) -> str:
         """md5 of a fresh screendump; "" when the dump failed."""
         if not self.frame_size():
             return ""
-        with open(self._probe, "rb") as probe:
-            return hashlib.md5(probe.read()).hexdigest()
+        return self.probe_hash()
 
     def sendkey(self, key: str) -> None:
         self._run(["qm", "sendkey", self.vmid, key], capture_output=True)
@@ -240,8 +248,18 @@ def run_unattended_install(
 
     boots = 0
     last_big = clock()
+    last_change = clock()
+    seen = ""
     while clock() - start < TOTAL_BUDGET:
         size = console.frame_size()
+        # macOS wedged behind the boot logo is exactly as quiet as a finished
+        # install: no picker, no 1080p frame. What separates them is motion.
+        # Running macOS always moves, if only because the Setup Assistant menu
+        # bar ticks its clock every minute; a wedged kernel never redraws.
+        digest = console.probe_hash()
+        if digest and digest != seen:
+            seen = digest
+            last_change = clock()
         if size > PICKER_MIN_BYTES:
             boots += 1
             last_big = clock()
@@ -251,6 +269,10 @@ def run_unattended_install(
             console.sendkey("ret")
             on_event(f"1080p frame {boots}: confirmed the only boot entry")
             sleep(30)
+        elif boots >= 1 and clock() - last_change > HUNG_STILL:
+            raise UnattendedError(
+                f"macOS appears hung: screen unchanged for {HUNG_STILL // 60} min"
+            )
         elif boots >= 1 and clock() - last_big > DONE_QUIET:
             elapsed = int(clock() - start)
             on_event(

--- a/src/osx_proxmox_next/unattended.py
+++ b/src/osx_proxmox_next/unattended.py
@@ -20,6 +20,7 @@ unattended_install (scripts/bash/osx-proxmox-next.sh); tests diff both.
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
 import subprocess
@@ -39,7 +40,9 @@ MACOS_MAX_BYTES = 4_500_000        # 1280x800 recovery / installer / Setup Assis
 PICKER_TIMEOUT = 600
 RECOVERY_TIMEOUT = 900
 INSTALL_REBOOT_TIMEOUT = 1800      # startosinstall prep before its first reboot
-RECOVERY_SETTLE = 240              # utilities window finishes loading well within this
+RECOVERY_SETTLE = 240              # minimum settle before the utilities window is looked for
+RECOVERY_STILL_MAX = 600           # extra grace while the recovery screen is still moving
+RECOVERY_STILL_FRAMES = 3          # identical consecutive frames = nothing animating
 TERMINAL_OPEN_WAIT = 10
 DONE_QUIET = 900                   # no picker for 15 min after reboots = install done
 TOTAL_BUDGET = 3 * 3600
@@ -113,6 +116,13 @@ class QmConsole:
         except FileNotFoundError:
             return 0
 
+    def frame_hash(self) -> str:
+        """md5 of a fresh screendump; "" when the dump failed."""
+        if not self.frame_size():
+            return ""
+        with open(self._probe, "rb") as probe:
+            return hashlib.md5(probe.read()).hexdigest()
+
     def sendkey(self, key: str) -> None:
         self._run(["qm", "sendkey", self.vmid, key], capture_output=True)
 
@@ -150,6 +160,32 @@ def _wait(console: QmConsole, predicate: Callable[[int], bool], timeout: float,
     raise UnattendedError(f"Timed out after {int(timeout)}s waiting for {what}")
 
 
+def _wait_still(console: QmConsole, on_event: Callable[[str], None],
+                clock: Callable[[], float], sleep: Callable[[float], None]) -> None:
+    """Hold until the recovery screen stops animating.
+
+    A cold first boot can still be in Recovery Assistant ("Examining
+    volumes", a spinner) when the settle expires. Its menu bar carries no
+    Utilities menu, so the Terminal navigation walks the wrong menu bar,
+    the command is typed into the utilities window that appears later and
+    its closing return runs the highlighted "Restore from Time Machine".
+    Identical consecutive frames mean nothing is animating any more, which
+    is only true once the utilities window is up."""
+    deadline = clock() + RECOVERY_STILL_MAX
+    seen = console.frame_hash()
+    still = 1
+    while clock() < deadline:
+        sleep(POLL_INTERVAL)
+        current = console.frame_hash()
+        if current and current == seen:
+            still += 1
+            if still >= RECOVERY_STILL_FRAMES:
+                return
+        else:
+            seen, still = current, 1
+    on_event("Recovery screen never stopped moving; navigating anyway")
+
+
 def run_unattended_install(
     console: QmConsole,
     disk_gb: int,
@@ -174,6 +210,7 @@ def run_unattended_install(
           "recovery to start", clock, sleep)
     on_event(f"Recovery is booting; settling {RECOVERY_SETTLE}s for the utilities window")
     sleep(RECOVERY_SETTLE)
+    _wait_still(console, on_event, clock, sleep)
 
     on_event("Opening Terminal from the Utilities menu")
     console.seq(TERMINAL_NAV)

--- a/tests/test_unattended.py
+++ b/tests/test_unattended.py
@@ -15,6 +15,8 @@ from osx_proxmox_next.unattended import (
     PICKER_TIMEOUT,
     POLL_INTERVAL,
     RECOVERY_SETTLE,
+    RECOVERY_STILL_FRAMES,
+    RECOVERY_STILL_MAX,
     RECOVERY_TIMEOUT,
     TERMINAL_NAV,
     TOTAL_BUDGET,
@@ -74,9 +76,11 @@ class FakeClock:
 class FakeConsole:
     """Frame sizes come from a schedule of (from_time, size) entries."""
 
-    def __init__(self, clock: FakeClock, schedule: list[tuple[float, int]]):
+    def __init__(self, clock: FakeClock, schedule: list[tuple[float, int]],
+                 moving_until: float = 0.0):
         self.clock = clock
         self.schedule = schedule
+        self.moving_until = moving_until
         self.keys: list[str] = []
         self.typed: list[str] = []
         self.qm_calls: list[tuple[str, ...]] = []
@@ -90,6 +94,15 @@ class FakeConsole:
             if self.clock.now >= start:
                 size = value
         return size
+
+    def frame_hash(self) -> str:
+        """An animating screen hashes differently on every poll."""
+        size = self.frame_size()
+        if not size:
+            return ""
+        if self.clock.now < self.moving_until:
+            return f"{size}-moving-{self.clock.now}"
+        return f"{size}-still"
 
     def sendkey(self, key: str) -> None:
         self.keys.append(key)
@@ -154,6 +167,45 @@ def test_full_install_happy_path() -> None:
     assert any("Done" in e for e in events)
 
 
+def test_terminal_nav_waits_for_a_still_screen() -> None:
+    """A cold boot still animating Recovery Assistant at the end of the
+    settle must not be navigated: the wrong menu bar is on screen."""
+    clock = FakeClock()
+    moving_until = RECOVERY_SETTLE + 300
+    console = FakeConsole(clock, [(0, 0), (30, PICKER), (60, 0), (200, MACOS),
+                                  (2000, PICKER), (2100, PICKER), (2130, MACOS),
+                                  (2700, PICKER), (2730, MACOS)],
+                          moving_until=moving_until)
+    events: list[str] = []
+    nav_at: list[float] = []
+    original = console.sendkey
+
+    def watched(key: str) -> None:
+        if key == "ctrl-f2":
+            nav_at.append(clock.now)
+        original(key)
+
+    console.sendkey = watched  # type: ignore[method-assign]
+    run_unattended_install(console, 128, on_event=events.append,
+                           clock=clock.monotonic, sleep=clock.sleep)
+    assert nav_at and nav_at[0] >= moving_until
+    assert not any("never stopped moving" in e for e in events)
+
+
+def test_still_wait_gives_up_and_says_so() -> None:
+    """A screen that never stops moving still gets navigated, with a note."""
+    clock = FakeClock()
+    console = FakeConsole(clock, [(0, 0), (30, PICKER), (60, 0), (200, MACOS),
+                                  (2000, PICKER), (2100, PICKER), (2130, MACOS),
+                                  (2700, PICKER), (2730, MACOS)],
+                          moving_until=float("inf"))
+    events: list[str] = []
+    run_unattended_install(console, 128, on_event=events.append,
+                           clock=clock.monotonic, sleep=clock.sleep)
+    assert any("never stopped moving" in e for e in events)
+    assert "ctrl-f2" in console.keys
+
+
 def test_picker_timeout_raises() -> None:
     with pytest.raises(UnattendedError, match="OpenCore picker"):
         _run([(0, 0)])
@@ -209,6 +261,21 @@ def test_qmconsole_frame_size_zero_without_dump() -> None:
     assert console.frame_size() == 0
 
 
+def test_qmconsole_frame_hash(tmp_path: Path) -> None:
+    """No dump means no hash; a dumped frame hashes its bytes."""
+    console = QmConsole(997, runner=lambda *a, **k: subprocess.CompletedProcess(a, 0),
+                        sleep=lambda s: None)
+    console._probe = str(tmp_path / "frame.ppm")
+    assert console.frame_hash() == ""
+
+    def dumping_runner(*args, **kwargs):
+        Path(console._probe).write_bytes(b"P6 frame")
+        return subprocess.CompletedProcess(args, 0)
+
+    console._run = dumping_runner
+    assert console.frame_hash() == "e0dc4968b8f2767a4b4fe1f0db9e640c"
+
+
 # ---------------------------------------------------------------------------
 # Bash parity
 # ---------------------------------------------------------------------------
@@ -224,6 +291,8 @@ def test_bash_constants_match_python(bash_text: str) -> None:
         "UNATTENDED_INSTALL_REBOOT_TIMEOUT": INSTALL_REBOOT_TIMEOUT,
         "UNATTENDED_PICKER_MIN_BYTES": PICKER_MIN_BYTES,
         "UNATTENDED_RECOVERY_SETTLE": RECOVERY_SETTLE,
+        "UNATTENDED_RECOVERY_STILL_MAX": RECOVERY_STILL_MAX,
+        "UNATTENDED_RECOVERY_STILL_FRAMES": RECOVERY_STILL_FRAMES,
         "UNATTENDED_PICKER_TIMEOUT": PICKER_TIMEOUT,
         "UNATTENDED_RECOVERY_TIMEOUT": RECOVERY_TIMEOUT,
         "UNATTENDED_DONE_QUIET": DONE_QUIET,
@@ -270,3 +339,10 @@ def test_bash_detaches_recovery_at_first_reboot(bash_text: str) -> None:
     assert 'qm set "$vmid" --delete ide2' in fn
     assert fn.index("unattended_install_command") < fn.index("--delete ide2")
     assert 'qm sendkey "$vmid" right' not in fn  # no blind entry-walking
+
+
+def test_bash_waits_for_a_still_screen_before_the_nav(bash_text: str) -> None:
+    fn = bash_text[bash_text.index("function unattended_install()"):]
+    assert fn.index('sleep "$UNATTENDED_RECOVERY_SETTLE"') \
+        < fn.index('unattended_wait_still "$vmid"') < fn.index("ctrl-f2")
+    assert "md5sum" in bash_text[bash_text.index("function unattended_frame_hash()"):]

--- a/tests/test_unattended.py
+++ b/tests/test_unattended.py
@@ -12,7 +12,9 @@ from osx_proxmox_next.unattended import (
     DONE_QUIET,
     HUNG_STILL,
     INSTALL_REBOOT_TIMEOUT,
+    MAX_POWER_CYCLES,
     PICKER_MIN_BYTES,
+    PICKER_REPRESS,
     PICKER_TIMEOUT,
     POLL_INTERVAL,
     RECOVERY_SETTLE,
@@ -249,18 +251,96 @@ def test_done_requires_at_least_one_boot_after_detach() -> None:
         _run([(0, 0), (30, PICKER), (60, MACOS)])
 
 
+WEDGED_SCHEDULE = [(0, 0), (30, PICKER), (60, 0), (200, MACOS),
+                   (1000, PICKER), (1100, PICKER), (1130, MACOS),
+                   (1700, PICKER), (1730, MACOS)]
+
+
+class RecoveringConsole(FakeConsole):
+    """A guest wedged on its last frame that comes back after a power cycle,
+    which is what the AMD field runs showed: qm reset leaves the vCPUs
+    spinning, a full stop/start boots the finished install to Setup
+    Assistant."""
+
+    def qm(self, subcommand: str, *args: str) -> str:
+        frozen = self.clock.now >= self.hung_from
+        out = super().qm(subcommand, *args)
+        if subcommand == "start" and frozen:
+            self.hung_from = float("inf")
+        return out
+
+
 def test_a_frozen_screen_is_never_done() -> None:
     """A wedged kernel is as quiet as a finished install. The screen going
-    byte-identical for HUNG_STILL is what tells them apart, and it must be
-    reported as a failure instead of a successful install."""
+    byte-identical for HUNG_STILL is what tells them apart, and it must never
+    be reported as a successful install."""
     clock = FakeClock()
-    console = FakeConsole(clock, [(0, 0), (30, PICKER), (60, 0), (200, MACOS),
-                                  (1000, PICKER), (1100, PICKER), (1130, MACOS),
-                                  (1700, PICKER), (1730, MACOS)],
-                          hung_from=1730)
+    console = FakeConsole(clock, WEDGED_SCHEDULE, hung_from=1730)
+    events: list[str] = []
     with pytest.raises(UnattendedError, match="appears hung"):
-        run_unattended_install(console, 128, on_event=lambda m: None,
+        run_unattended_install(console, 128, on_event=events.append,
                                clock=clock.monotonic, sleep=clock.sleep)
+    assert not any("Done" in e for e in events)
+
+
+def test_a_wedged_guest_is_power_cycled_and_then_finishes() -> None:
+    """The install itself is done; only the guest's reboot wedged. One
+    stop/start clears it and the run reports success."""
+    clock = FakeClock()
+    console = RecoveringConsole(clock, WEDGED_SCHEDULE, hung_from=1730)
+    events: list[str] = []
+    summary = run_unattended_install(console, 128, on_event=events.append,
+                                     clock=clock.monotonic, sleep=clock.sleep)
+    assert any("power-cycling" in e for e in events)
+    # one stop for the recovery detach, one for the power cycle, no qm reset
+    assert console.qm_calls.count(("stop",)) == 2
+    assert console.qm_calls.count(("start",)) == 2
+    assert not any(call[0] == "reset" for call in console.qm_calls)
+    assert summary["reboots"] >= 1
+
+
+def test_power_cycling_gives_up_after_the_cap() -> None:
+    """A guest that wedges again after every cycle is a real failure."""
+    clock = FakeClock()
+    console = FakeConsole(clock, WEDGED_SCHEDULE, hung_from=1730)
+    events: list[str] = []
+    with pytest.raises(UnattendedError, match="appears hung"):
+        run_unattended_install(console, 128, on_event=events.append,
+                               clock=clock.monotonic, sleep=clock.sleep)
+    assert sum("power-cycling" in e for e in events) == MAX_POWER_CYCLES
+    assert console.qm_calls.count(("stop",)) == 1 + MAX_POWER_CYCLES
+
+
+class ParkedPickerConsole(FakeConsole):
+    """The OpenCore picker never redraws, so a parked one keeps a single md5
+    (Timeout=0 waits forever when the first return is dropped)."""
+
+    def probe_hash(self) -> str:
+        size = self.frame_size()
+        if not size:
+            return ""
+        if size > PICKER_MIN_BYTES:
+            return "picker"
+        return f"{size}-{int(self.clock.now // 60)}"
+
+
+def test_a_parked_picker_gets_pressed_again() -> None:
+    """A picker sitting on the same frame is re-pressed on a throttle, and
+    logs one line for the boot instead of one per poll."""
+    clock = FakeClock()
+    console = ParkedPickerConsole(
+        clock, [(0, 0), (30, PICKER), (60, 0), (200, MACOS),
+                (1000, PICKER), (1400, MACOS)])
+    events: list[str] = []
+    summary = run_unattended_install(console, 128, on_event=events.append,
+                                     clock=clock.monotonic, sleep=clock.sleep)
+    assert sum("1080p frame" in e for e in events) == 1
+    assert summary["reboots"] == 1
+    # 3 returns before the loop (picker, Terminal nav, command), then one per
+    # boot plus the throttled re-presses: many fewer than one per 6s poll.
+    presses = console.keys.count("ret") - 3
+    parked_for = 1400 - 1000
+    assert 5 <= presses <= parked_for // PICKER_REPRESS + 3
 
 
 def test_hung_detection_fires_before_the_done_window() -> None:
@@ -332,6 +412,8 @@ def test_bash_constants_match_python(bash_text: str) -> None:
         "UNATTENDED_RECOVERY_TIMEOUT": RECOVERY_TIMEOUT,
         "UNATTENDED_DONE_QUIET": DONE_QUIET,
         "UNATTENDED_HUNG_STILL": HUNG_STILL,
+        "UNATTENDED_PICKER_REPRESS": PICKER_REPRESS,
+        "UNATTENDED_MAX_POWER_CYCLES": MAX_POWER_CYCLES,
         "UNATTENDED_TOTAL_BUDGET": TOTAL_BUDGET,
         "UNATTENDED_POLL": POLL_INTERVAL,
     }
@@ -389,3 +471,19 @@ def test_bash_refuses_to_call_a_frozen_screen_done(bash_text: str) -> None:
     assert fn.index("UNATTENDED_HUNG_STILL") < fn.index("UNATTENDED_DONE_QUIET")
     assert "macOS appears hung" in fn
     assert "unattended_probe_hash" in fn
+
+
+def test_bash_power_cycles_a_wedged_guest(bash_text: str) -> None:
+    fn = bash_text[bash_text.index("function unattended_install()"):]
+    assert "power-cycling" in fn
+    assert fn.index("UNATTENDED_MAX_POWER_CYCLES") < fn.index("power-cycling")
+    assert "unattended_wait_stopped" in fn
+    assert not re.search(r"^\s*qm reset", bash_text, re.M)   # reset never clears it
+    assert "last_change <= UNATTENDED_DONE_QUIET" in fn   # done needs a moving screen
+
+
+def test_bash_represses_a_parked_picker(bash_text: str) -> None:
+    fn = bash_text[bash_text.index("function unattended_install()"):]
+    assert "UNATTENDED_PICKER_REPRESS" in fn
+    # picker, command, the per-boot press and the parked re-press
+    assert fn.count('qm sendkey "$vmid" ret') == 4

--- a/tests/test_unattended.py
+++ b/tests/test_unattended.py
@@ -10,6 +10,7 @@ import pytest
 from osx_proxmox_next.unattended import (
     CHARMAP,
     DONE_QUIET,
+    HUNG_STILL,
     INSTALL_REBOOT_TIMEOUT,
     PICKER_MIN_BYTES,
     PICKER_TIMEOUT,
@@ -77,10 +78,11 @@ class FakeConsole:
     """Frame sizes come from a schedule of (from_time, size) entries."""
 
     def __init__(self, clock: FakeClock, schedule: list[tuple[float, int]],
-                 moving_until: float = 0.0):
+                 moving_until: float = 0.0, hung_from: float = float("inf")):
         self.clock = clock
         self.schedule = schedule
         self.moving_until = moving_until
+        self.hung_from = hung_from
         self.keys: list[str] = []
         self.typed: list[str] = []
         self.qm_calls: list[tuple[str, ...]] = []
@@ -103,6 +105,16 @@ class FakeConsole:
         if self.clock.now < self.moving_until:
             return f"{size}-moving-{self.clock.now}"
         return f"{size}-still"
+
+    def probe_hash(self) -> str:
+        """Live macOS redraws its menu-bar clock every minute; a wedged one
+        returns the same frame forever."""
+        size = self.frame_size()
+        if not size:
+            return ""
+        if self.clock.now >= self.hung_from:
+            return "frozen"
+        return f"{size}-{int(self.clock.now // 60)}"
 
     def sendkey(self, key: str) -> None:
         self.keys.append(key)
@@ -237,6 +249,25 @@ def test_done_requires_at_least_one_boot_after_detach() -> None:
         _run([(0, 0), (30, PICKER), (60, MACOS)])
 
 
+def test_a_frozen_screen_is_never_done() -> None:
+    """A wedged kernel is as quiet as a finished install. The screen going
+    byte-identical for HUNG_STILL is what tells them apart, and it must be
+    reported as a failure instead of a successful install."""
+    clock = FakeClock()
+    console = FakeConsole(clock, [(0, 0), (30, PICKER), (60, 0), (200, MACOS),
+                                  (1000, PICKER), (1100, PICKER), (1130, MACOS),
+                                  (1700, PICKER), (1730, MACOS)],
+                          hung_from=1730)
+    with pytest.raises(UnattendedError, match="appears hung"):
+        run_unattended_install(console, 128, on_event=lambda m: None,
+                               clock=clock.monotonic, sleep=clock.sleep)
+
+
+def test_hung_detection_fires_before_the_done_window() -> None:
+    """Otherwise a frozen screen would still be declared done first."""
+    assert HUNG_STILL < DONE_QUIET
+
+
 # ---------------------------------------------------------------------------
 # QmConsole plumbing
 # ---------------------------------------------------------------------------
@@ -267,6 +298,7 @@ def test_qmconsole_frame_hash(tmp_path: Path) -> None:
                         sleep=lambda s: None)
     console._probe = str(tmp_path / "frame.ppm")
     assert console.frame_hash() == ""
+    assert console.probe_hash() == ""   # nothing dumped yet
 
     def dumping_runner(*args, **kwargs):
         Path(console._probe).write_bytes(b"P6 frame")
@@ -274,6 +306,9 @@ def test_qmconsole_frame_hash(tmp_path: Path) -> None:
 
     console._run = dumping_runner
     assert console.frame_hash() == "e0dc4968b8f2767a4b4fe1f0db9e640c"
+    # probe_hash re-reads what frame_size already wrote, without dumping again
+    console._run = lambda *a, **k: subprocess.CompletedProcess(a, 0)
+    assert console.probe_hash() == "e0dc4968b8f2767a4b4fe1f0db9e640c"
 
 
 # ---------------------------------------------------------------------------
@@ -296,6 +331,7 @@ def test_bash_constants_match_python(bash_text: str) -> None:
         "UNATTENDED_PICKER_TIMEOUT": PICKER_TIMEOUT,
         "UNATTENDED_RECOVERY_TIMEOUT": RECOVERY_TIMEOUT,
         "UNATTENDED_DONE_QUIET": DONE_QUIET,
+        "UNATTENDED_HUNG_STILL": HUNG_STILL,
         "UNATTENDED_TOTAL_BUDGET": TOTAL_BUDGET,
         "UNATTENDED_POLL": POLL_INTERVAL,
     }
@@ -345,4 +381,11 @@ def test_bash_waits_for_a_still_screen_before_the_nav(bash_text: str) -> None:
     fn = bash_text[bash_text.index("function unattended_install()"):]
     assert fn.index('sleep "$UNATTENDED_RECOVERY_SETTLE"') \
         < fn.index('unattended_wait_still "$vmid"') < fn.index("ctrl-f2")
-    assert "md5sum" in bash_text[bash_text.index("function unattended_frame_hash()"):]
+    assert "md5sum" in bash_text[bash_text.index("function unattended_probe_hash()"):]
+
+
+def test_bash_refuses_to_call_a_frozen_screen_done(bash_text: str) -> None:
+    fn = bash_text[bash_text.index("function unattended_install()"):]
+    assert fn.index("UNATTENDED_HUNG_STILL") < fn.index("UNATTENDED_DONE_QUIET")
+    assert "macOS appears hung" in fn
+    assert "unattended_probe_hash" in fn


### PR DESCRIPTION
## Summary

The unattended driver had two ways to lose a run on a cold host: it opened Terminal before the recovery screen had finished loading and it could not tell a wedged guest from a finished install. Both come down to the same missing signal, whether the screen is actually changing, so the driver now watches for motion instead of trusting fixed timers.

## Changes

- Wait for a stable recovery screen before the Terminal navigation instead of relying on a fixed 240 s settle. Three identical consecutive frames mean nothing is animating any more, which is only true once the utilities window is really up.
- Treat a screen that has not changed for 10 minutes as a wedged guest. The driver stops and starts the VM, up to twice, and never uses `qm reset`, which does not clear an MP rendezvous with every vCPU spinning.
- Re-send Enter on a picker that stays parked on the same frame, so one dropped keystroke no longer stalls the whole run. The log still gets one line per boot rather than one per poll.
- Require a recently changed screen before declaring Done. A frozen Apple logo is exactly as quiet as a finished install, so quiet alone is no longer enough.
- Mirror all of it in `scripts/bash/osx-proxmox-next.sh` for Python/bash parity.
- Tests covering the stability wait, the wedge detection, the power-cycle cap and the Done guard.

## Testing

- [x] `pytest` green, 1042 passed and 2 skipped
- [x] Coverage 97.67%, above the 95% gate in `pyproject.toml`
- [x] Live validation on an AMD 5950X node running PVE 9.1.7: cold-boot Terminal navigation confirmed, the stability wait lands on the utilities window every time
- [x] Wedge recovery confirmed, the frozen stage-2 boot was cleared by a stop/start three times in a row
