### PR TITLE
fix(preflight): check the live kvm ignore_msrs value, self-heal in bash

### DIFF
--- a/scripts/bash/osx-proxmox-next.sh
+++ b/scripts/bash/osx-proxmox-next.sh
@@ -330,6 +330,25 @@ function check_dependencies() {
   fi
 }
 
+# ── Make sure KVM really ignores unsupported MSR reads ──
+# kvm.conf is only read when the module loads, so a node where the file was
+# written after kvm was already up (and never rebooted) still runs with
+# ignore_msrs=N and hangs macOS at the Apple logo. Set the live value too.
+function ensure_ignore_msrs() {
+  local param="/sys/module/kvm/parameters/ignore_msrs"
+  if ! grep -qs "ignore_msrs=Y" /etc/modprobe.d/kvm.conf; then
+    echo "options kvm ignore_msrs=Y" >>/etc/modprobe.d/kvm.conf
+    msg_ok "Persisted ignore_msrs=Y in /etc/modprobe.d/kvm.conf"
+  fi
+  [ -f "$param" ] || return 0
+  [ "$(cat "$param")" = "N" ] || return 0
+  if echo Y >"$param" 2>/dev/null; then
+    msg_ok "Enabled ignore_msrs on the running kvm module"
+  else
+    msg_error "Could not set ${param} - macOS will hang at the Apple logo"
+  fi
+}
+
 # ── Detect CPU vendor and model ──
 function detect_cpu_vendor() {
   if grep -q "AuthenticAMD" /proc/cpuinfo 2>/dev/null; then
@@ -1606,6 +1625,7 @@ arch_check
 pve_check
 ssh_check
 check_dependencies
+ensure_ignore_msrs
 start_script
 
 # Both settings paths have set RAM_SIZE by now; refuse to continue when the

--- a/src/osx_proxmox_next/preflight.py
+++ b/src/osx_proxmox_next/preflight.py
@@ -51,24 +51,53 @@ _BUILD_BINARIES: dict[str, str] = {
 }
 
 
-def _check_ignore_msrs(kvm_conf: Path | None = None) -> PreflightCheck:
-    """Check if KVM ignore_msrs=Y is set - critical for macOS (prevents MSR kernel panics)."""
+def _check_ignore_msrs(
+    kvm_conf: Path | None = None,
+    sysfs_path: Path | None = None,
+) -> PreflightCheck:
+    """Check that the running KVM module ignores unsupported MSR reads.
+
+    kvm.conf is only read when the module loads. On a node where the file was
+    written after kvm was already loaded and never rebooted, the conf says Y
+    while /sys/module/kvm/parameters/ignore_msrs still says N, and macOS hangs
+    at the Apple logo. The live sysfs value is the only one that decides, so the
+    conf file is treated as the persistence hint, not as the answer.
+    """
     if kvm_conf is None:
         kvm_conf = Path("/etc/modprobe.d/kvm.conf")
-    if kvm_conf.exists():
-        content = kvm_conf.read_text()
-        if "ignore_msrs=Y" in content:
-            return PreflightCheck(
-                name="KVM ignore_msrs",
-                ok=True,
-                details="ignore_msrs=Y set in /etc/modprobe.d/kvm.conf",
-            )
-    return PreflightCheck(
-        name="KVM ignore_msrs",
-        ok=False,
-        details="Missing ignore_msrs=Y - macOS will kernel panic on unsupported MSR access. "
-                "Fix: echo 'options kvm ignore_msrs=Y' >> /etc/modprobe.d/kvm.conf && update-initramfs -k all -u",
-    )
+    if sysfs_path is None:
+        sysfs_path = Path("/sys/module/kvm/parameters/ignore_msrs")
+
+    persisted = kvm_conf.exists() and "ignore_msrs=Y" in kvm_conf.read_text()
+    live = sysfs_path.read_text().strip() if sysfs_path.exists() else ""
+
+    if live in ("Y", "1"):
+        persistence = (
+            "persisted in /etc/modprobe.d/kvm.conf"
+            if persisted
+            else "not persisted, add 'options kvm ignore_msrs=Y' to "
+                 "/etc/modprobe.d/kvm.conf so it survives a reboot"
+        )
+        return PreflightCheck(
+            name="KVM ignore_msrs",
+            ok=True,
+            details=f"ignore_msrs=Y on the running kvm module ({persistence})",
+        )
+
+    if persisted:
+        details = (
+            "ignore_msrs=Y is in /etc/modprobe.d/kvm.conf but the running kvm module has not "
+            "picked it up (sysfs still reports N), so macOS will hang at the Apple logo. "
+            "Fix, no reboot needed: echo Y > /sys/module/kvm/parameters/ignore_msrs"
+        )
+    else:
+        details = (
+            "Missing ignore_msrs=Y - macOS will kernel panic on unsupported MSR access. "
+            "Fix now, no reboot needed: echo Y > /sys/module/kvm/parameters/ignore_msrs - "
+            "then persist it: echo 'options kvm ignore_msrs=Y' >> /etc/modprobe.d/kvm.conf "
+            "&& update-initramfs -k all -u"
+        )
+    return PreflightCheck(name="KVM ignore_msrs", ok=False, details=details)
 
 
 def _check_iommu(cmdline_path: Path | None = None) -> PreflightCheck:

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -96,30 +96,68 @@ def test_find_binary_which_found(monkeypatch):
     assert preflight._find_binary("qm") == "/usr/bin/qm"
 
 
-def test_check_ignore_msrs_present(tmp_path):
-    """When kvm.conf has ignore_msrs=Y, check must pass."""
+def _msrs_paths(tmp_path, conf, live):
     kvm_conf = tmp_path / "kvm.conf"
-    kvm_conf.write_text("options kvm ignore_msrs=Y\n")
-    check = preflight._check_ignore_msrs(kvm_conf=kvm_conf)
+    if conf is not None:
+        kvm_conf.write_text(conf)
+    sysfs = tmp_path / "ignore_msrs"
+    if live is not None:
+        sysfs.write_text(live)
+    return kvm_conf, sysfs
+
+
+def test_check_ignore_msrs_present(tmp_path):
+    """When the conf has ignore_msrs=Y and the module agrees, check must pass."""
+    kvm_conf, sysfs = _msrs_paths(tmp_path, "options kvm ignore_msrs=Y\n", "Y\n")
+    check = preflight._check_ignore_msrs(kvm_conf=kvm_conf, sysfs_path=sysfs)
     assert check.name == "KVM ignore_msrs"
     assert check.ok is True
     assert "ignore_msrs=Y" in check.details
+    assert "persisted in /etc/modprobe.d/kvm.conf" in check.details
+
+
+def test_check_ignore_msrs_live_but_not_persisted(tmp_path):
+    """Live Y with no conf entry passes but warns it will not survive a reboot."""
+    kvm_conf, sysfs = _msrs_paths(tmp_path, None, "1\n")
+    check = preflight._check_ignore_msrs(kvm_conf=kvm_conf, sysfs_path=sysfs)
+    assert check.ok is True
+    assert "not persisted" in check.details
+
+
+def test_check_ignore_msrs_conf_set_but_module_stale(tmp_path):
+    """Conf says Y, running module says N: the live value decides, so it fails."""
+    kvm_conf, sysfs = _msrs_paths(tmp_path, "options kvm ignore_msrs=Y\n", "N\n")
+    check = preflight._check_ignore_msrs(kvm_conf=kvm_conf, sysfs_path=sysfs)
+    assert check.ok is False
+    assert "has not picked it up" in check.details
+    assert "echo Y > /sys/module/kvm/parameters/ignore_msrs" in check.details
 
 
 def test_check_ignore_msrs_missing(tmp_path):
-    """When kvm.conf doesn't exist, check must fail."""
-    check = preflight._check_ignore_msrs(kvm_conf=tmp_path / "nonexistent")
+    """When neither the conf nor sysfs has it, check must fail."""
+    check = preflight._check_ignore_msrs(
+        kvm_conf=tmp_path / "nonexistent",
+        sysfs_path=tmp_path / "no-sysfs",
+    )
     assert check.name == "KVM ignore_msrs"
     assert check.ok is False
     assert "ignore_msrs=Y" in check.details
+    assert "echo Y > /sys/module/kvm/parameters/ignore_msrs" in check.details
 
 
 def test_check_ignore_msrs_present_but_wrong_value(tmp_path):
     """When kvm.conf exists but lacks ignore_msrs=Y, check must fail."""
-    kvm_conf = tmp_path / "kvm.conf"
-    kvm_conf.write_text("options kvm report_ignored_msrs=N\n")
-    check = preflight._check_ignore_msrs(kvm_conf=kvm_conf)
+    kvm_conf, sysfs = _msrs_paths(tmp_path, "options kvm report_ignored_msrs=N\n", "N\n")
+    check = preflight._check_ignore_msrs(kvm_conf=kvm_conf, sysfs_path=sysfs)
     assert check.ok is False
+
+
+def test_bash_script_sets_live_ignore_msrs():
+    """Parity: the bash script must write the live sysfs value, not just the conf."""
+    script = (Path(__file__).resolve().parent.parent / "scripts/bash/osx-proxmox-next.sh").read_text()
+    assert "function ensure_ignore_msrs()" in script
+    assert "/sys/module/kvm/parameters/ignore_msrs" in script
+    assert "\nensure_ignore_msrs\n" in script
 
 
 def test_check_iommu_enabled(tmp_path):


### PR DESCRIPTION
## Summary

The `ignore_msrs` preflight check read `/etc/modprobe.d/kvm.conf` and called a match a pass. That file is only consulted when the kvm module loads, so a node that got the line after kvm was already up still runs with `ignore_msrs=N` and hangs macOS at the Apple logo while the check reports green.

## Changes

- Read `/sys/module/kvm/parameters/ignore_msrs` and let the live value decide the check. The conf file is now the persistence hint rather than the answer.
- Give each state its own remediation line: live Y but not persisted, persisted but not picked up by the running module, and neither of the two. All of them lead with the `echo Y > /sys/module/kvm/parameters/ignore_msrs` fix that needs no reboot.
- The bash script self-heals in `ensure_ignore_msrs`: it appends the option to `kvm.conf` when it is missing and writes Y into sysfs when the running module still says N, before any VM is created.
- Tests for every combination of conf and sysfs state.

## Testing

- [x] `pytest` green, 1045 passed and 2 skipped
- [x] Coverage 97.67%, above the 95% gate in `pyproject.toml`
- [x] Checked on an AMD 5950X node running PVE 9.1.7 where sysfs reports Y, the check now names the running module instead of the file
