### PR TITLE
ci: block disallowed trailers in pull request commits and text

### DIFF
--- a/.githooks/check-attribution.sh
+++ b/.githooks/check-attribution.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Scan text on stdin for AI attribution. Exit 1 if any is found.
+# Lives in .githooks/ because the pre-commit hook exempts this directory,
+# which is the only place the patterns can be written out literally.
+set -euo pipefail
+
+AI_PATTERNS=(
+  '🤖'
+  'Generated with.*Claude'
+  'Generated with.*Codex'
+  'Co-Authored-By:[[:space:]]*Claude'
+  'Co-Authored-By:[[:space:]]*Codex'
+  'Claude-Session:'
+  'Codex-Session:'
+  'anthropic\.com'
+  'noreply@anthropic'
+  'openai\.com'
+  'claude\.ai/code/session'
+)
+
+AI_REGEX=$(IFS='|'; echo "${AI_PATTERNS[*]}")
+
+if MATCHES=$(grep -inE "$AI_REGEX"); then
+  echo "$MATCHES"
+  echo
+  echo "AI attribution found in the lines above."
+  echo "Squash merges are assembled by GitHub, so local hooks cannot catch them."
+  echo "Reword the offending commits, force-push the branch, then fix the pull request text."
+  exit 1
+fi
+
+echo "No AI attribution found."

--- a/.github/workflows/attribution.yml
+++ b/.github/workflows/attribution.yml
@@ -1,0 +1,25 @@
+name: Attribution
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  no-ai-attribution:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Scan commit messages, title and body
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          {
+            git log --format='%B' "$BASE_SHA..$HEAD_SHA"
+            printf '%s\n%s\n' "$PR_TITLE" "$PR_BODY"
+          } | bash .githooks/check-attribution.sh


### PR DESCRIPTION
## Summary

Two merged commits landed on main carrying trailers that the project does not allow. The local hooks never ran on them and cannot see a squash message that GitHub assembles server-side anyway. This adds a check that runs where the merge happens.

## Changes

- A script under `.githooks/` reads text on stdin and fails when it finds a disallowed trailer or footer.
- A workflow runs on every pull request and pipes the branch commit messages plus the pull request title and body through that script.

## Testing

- [x] Scanner passes on a clean message and exits 1 on a message with a disallowed trailer
- [x] This pull request exercises the workflow against its own commits